### PR TITLE
Fix first layer height of Artillery 0.28mm profile

### DIFF
--- a/live/Artillery/0.0.3.ini
+++ b/live/Artillery/0.0.3.ini
@@ -300,6 +300,7 @@ top_solid_layers = 4
 [print:*0.28mm*]
 inherits = *common*
 layer_height = 0.28
+first_layer_height = 0.36
 top_infill_extrusion_width = 0.45
 first_layer_extrusion_width = 0.75
 bottom_solid_layers = 3


### PR DESCRIPTION
The Artillery "0.28 SUPERDRAFT" profile uses a default first layer height of "150%". This exceeds the diameter of the default 0.4mm nozzle and leads to a slicer error: "First layer height can't be greater than nozzle diameter"

This change sets this specific profile's first layer height to 0.36mm. Tested on Artillery Sidewinder & Genius.