### PR TITLE
Ultimaker profile: use classic intro line for nozzle priming

### DIFF
--- a/live/Ultimaker/1.0.1.ini
+++ b/live/Ultimaker/1.0.1.ini
@@ -1,0 +1,400 @@
+# Print profiles for the Ultimaker printers.
+# https://github.com/prusa3d/PrusaSlicer-settings/issues/143
+# author: https://github.com/foreachthing
+
+
+[vendor]
+# Vendor name will be shown by the Config Wizard.
+name = Ultimaker
+
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the PrusaSlicer configuration to be downgraded.
+config_version = 1.0.1
+
+# Where to get the updates from?
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Ultimaker/
+
+# The printer models will be shown by the Configuration Wizard in this order,
+# also the first model installed & the first nozzle installed will be activated after install.
+# Printer model name will be shown by the installation wizard.
+
+[printer_model:ULTIMAKER2]
+name = Ultimaker 2
+variants = 0.4
+technology = FFF
+bed_model = ultimaker2_bed.stl
+bed_texture = ultimaker2.svg
+default_materials = Generic PLA @ULTIMAKER2; Generic PETG @ULTIMAKER2; Generic ABS @ULTIMAKER2
+
+# All presets starting with asterisk, for example *common*, are intermediate and they will
+# not make it into the user interface.
+
+# Common print preset
+[print:*common*]
+avoid_crossing_perimeters = 1
+avoid_crossing_perimeters_max_detour = 0
+bottom_fill_pattern = rectilinear
+bottom_solid_layers = 4
+bottom_solid_min_thickness = 0
+bridge_acceleration = 0
+bridge_angle = 0
+bridge_flow_ratio = 1
+bridge_speed = 60
+brim_separation = 0
+brim_type = outer_only
+brim_width = 0
+clip_multipart_objects = 0
+compatible_printers = 
+compatible_printers_condition = 
+complete_objects = 0
+default_acceleration = 0
+dont_support_bridges = 0
+draft_shield = disabled
+elefant_foot_compensation = 0
+ensure_vertical_shell_thickness = 0
+external_perimeter_extrusion_width = 0.45
+external_perimeter_speed = 75%
+external_perimeters_first = 0
+extra_perimeters = 1
+extruder_clearance_height = 50
+extruder_clearance_radius = 60
+extrusion_width = 0.45
+fill_angle = 45
+fill_density = 20%
+fill_pattern = grid
+first_layer_acceleration = 0
+first_layer_acceleration_over_raft = 0
+first_layer_extrusion_width = 0.45
+first_layer_height = 0.2
+first_layer_speed = 30
+first_layer_speed_over_raft = 30
+fuzzy_skin = none
+fuzzy_skin_point_dist = 0.8
+fuzzy_skin_thickness = 0.3
+gap_fill_enabled = 1
+gap_fill_speed = 20
+gcode_comments = 1
+gcode_label_objects = 0
+infill_acceleration = 0
+infill_anchor = 600%
+infill_anchor_max = 50
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.5
+infill_first = 1
+infill_only_where_needed = 0
+infill_overlap = 35%
+infill_speed = 60
+inherits = 
+interface_shells = 0
+ironing = 0
+ironing_flowrate = 15%
+ironing_spacing = 0.1
+ironing_speed = 15
+ironing_type = top
+layer_height = 0.2
+max_print_speed = 80
+max_volumetric_speed = 0
+min_skirt_length = 2
+mmu_segmented_region_max_width = 0
+notes = Ultimaker 2, 0.4 mm Nozzle
+only_retract_when_crossing_perimeters = 1
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+overhangs = 1
+perimeter_acceleration = 0
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.45
+perimeter_speed = 50
+perimeters = 2
+post_process = 
+print_settings_id = 
+raft_contact_distance = 0.1
+raft_expansion = 1.5
+raft_first_layer_density = 90%
+raft_first_layer_expansion = 3
+raft_layers = 0
+resolution = 0
+seam_position = aligned
+single_extruder_multi_material_priming = 1
+skirt_distance = 3
+skirt_height = 1
+skirts = 1
+slice_closing_radius = 0.049
+slicing_mode = regular
+small_perimeter_speed = 75%
+solid_infill_below_area = 10
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.45
+solid_infill_speed = 40
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 0
+support_material_angle = 45
+support_material_auto = 1
+support_material_bottom_contact_distance = 0
+support_material_bottom_interface_layers = -1
+support_material_buildplate_only = 1
+support_material_closing_radius = 2
+support_material_contact_distance = 0.2
+support_material_enforce_layers = 0
+support_material_extruder = 1
+support_material_extrusion_width = 0.4
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 1
+support_material_interface_layers = 2
+support_material_interface_pattern = auto
+support_material_interface_spacing = 0.2
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear-grid
+support_material_spacing = 4
+support_material_speed = 60
+support_material_style = grid
+support_material_synchronize_layers = 0
+support_material_threshold = 0
+support_material_with_sheath = 0
+support_material_xy_spacing = 0.8
+thick_bridges = 1
+thin_walls = 0
+threads = 8
+top_fill_pattern = rectilinear
+top_infill_extrusion_width = 0.45
+top_solid_infill_speed = 40
+top_solid_layers = 4
+top_solid_min_thickness = 0
+travel_speed = 120
+travel_speed_z = 0
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_brim_width = 2
+wipe_tower_no_sparse_layers = 0
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 180
+wipe_tower_y = 140
+xy_size_compensation = 0
+
+
+[print:*0.12mm*]
+inherits = *common*
+perimeter_speed = 40
+external_perimeter_speed = 25
+infill_speed = 50
+solid_infill_speed = 40
+layer_height = 0.12
+perimeters = 3
+top_infill_extrusion_width = 0.4
+bottom_solid_layers = 6
+top_solid_layers = 7
+
+[print:*0.20mm*]
+inherits = *common*
+perimeter_speed = 40
+external_perimeter_speed = 25
+infill_speed = 50
+solid_infill_speed = 40
+layer_height = 0.20
+top_infill_extrusion_width = 0.4
+bottom_solid_layers = 4
+top_solid_layers = 5
+
+[print:*0.25mm*]
+inherits = *common*
+perimeter_speed = 40
+external_perimeter_speed = 25
+infill_speed = 50
+solid_infill_speed = 40
+layer_height = 0.25
+top_infill_extrusion_width = 0.45
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+[print:0.12mm DETAIL @ULTIMAKER2]
+inherits = *0.12mm*
+travel_speed = 150
+infill_speed = 50
+solid_infill_speed = 40
+top_solid_infill_speed = 30
+support_material_extrusion_width = 0.38
+compatible_printers_condition = printer_model=="ULTIMAKER2" and nozzle_diameter[0]==0.4
+
+[print:0.20mm NORMAL @ULTIMAKER2]
+inherits = *0.20mm*
+travel_speed = 150
+infill_speed = 50
+solid_infill_speed = 40
+top_solid_infill_speed = 30
+support_material_extrusion_width = 0.38
+compatible_printers_condition = printer_model=="ULTIMAKER2" and nozzle_diameter[0]==0.4
+
+[print:0.25mm DRAFT @ULTIMAKER2]
+inherits = *0.25mm*
+travel_speed = 150
+infill_speed = 50
+solid_infill_speed = 40
+top_solid_infill_speed = 30
+support_material_extrusion_width = 0.38
+compatible_printers_condition = printer_model=="ULTIMAKER2" and nozzle_diameter[0]==0.4
+
+# Common filament preset
+[filament:*common*]
+cooling = 0
+compatible_printers = 
+extrusion_multiplier = 1
+filament_cost = 0
+filament_density = 0
+filament_diameter = 2.85
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 15
+slowdown_below_layer_time = 20
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ULTIMAKER.*/
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+fan_below_layer_time = 100
+filament_colour = #FFF0E0
+filament_max_volumetric_speed = 0
+filament_type = PLA
+filament_density = 1.24
+first_layer_bed_temperature = 55
+first_layer_temperature = 205
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 100
+max_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 3
+temperature = 210
+
+[filament:*PET*]
+inherits = *common*
+fan_below_layer_time = 15
+filament_colour = #FFF0E0
+filament_max_volumetric_speed = 0
+filament_type = PETG
+filament_density = 1.27
+first_layer_bed_temperature = 85
+bed_temperature = 85
+first_layer_temperature = 240
+temperature = 235
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 40
+bridge_fan_speed = 40
+slowdown_below_layer_time = 15
+min_print_speed = 10
+disable_fan_first_layers = 3
+
+[filament:*ABS*]
+inherits = *common*
+fan_below_layer_time = 15
+filament_colour = #FFF0E0
+filament_max_volumetric_speed = 0
+filament_type = ABS
+filament_density = 1.10
+first_layer_bed_temperature = 80
+bed_temperature = 80
+first_layer_temperature = 240
+temperature = 235
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 5
+max_fan_speed = 5
+bridge_fan_speed = 10
+slowdown_below_layer_time = 15
+min_print_speed = 10
+disable_fan_first_layers = 3
+
+[filament:Generic PLA @ULTIMAKER2]
+inherits = *PLA*
+filament_vendor = Generic
+filament_cost = 
+
+[filament:Generic Black PLA @ULTIMAKER2]
+inherits = *PLA*
+filament_vendor = Generic
+filament_colour = #0E3F3F
+filament_cost = 
+
+[filament:Generic PETG @ULTIMAKER2]
+inherits = *PET*
+filament_vendor = Generic
+filament_cost = 
+
+[filament:Generic ABS @ULTIMAKER2]
+inherits = *ABS*
+filament_vendor = Generic
+filament_cost = 
+
+# Common printer preset
+[printer:*common*]
+printer_technology = FFF
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;layer:[layer_num];\nM117 Layer [layer_num];\n
+between_objects_gcode = 
+deretract_speed = 0
+extruder_colour = #FFF0E0
+extruder_offset = 0x0
+gcode_flavor = reprap
+silent_mode = 0
+remaining_times = 0
+machine_max_acceleration_e = 10000
+machine_max_acceleration_extruding = 1500
+machine_max_acceleration_retracting = 1500
+machine_max_acceleration_x = 3000
+machine_max_acceleration_y = 3000
+machine_max_acceleration_z = 500
+machine_max_feedrate_e = 120
+machine_max_feedrate_x = 500
+machine_max_feedrate_y = 500
+machine_max_feedrate_z = 12
+machine_max_jerk_e = 2.5
+machine_max_jerk_x = 20
+machine_max_jerk_y = 20
+machine_max_jerk_z = 0.4
+machine_min_extruding_rate = 0
+machine_min_travel_rate = 0
+layer_gcode = 
+max_print_height = 212
+octoprint_apikey = 
+octoprint_host = 
+printer_notes = 
+printer_settings_id = 
+retract_before_travel = 5
+retract_before_wipe = 0%
+retract_layer_change = 1
+retract_length = 6
+retract_length_toolchange = 10
+retract_lift = 0
+retract_lift_above = 0
+retract_lift_below = 0
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 50
+serial_port = 
+single_extruder_multi_material = 0
+toolchange_gcode = 
+use_firmware_retraction = 0
+use_relative_e_distances = 0
+use_volumetric_e = 0
+variable_layer_height = 1
+wipe = 0
+z_offset = 0
+
+[printer:Ultimaker 2]
+inherits = *common*
+printer_model = ULTIMAKER2
+bed_shape = 0x0,224x0,224x225,0x225
+printer_variant = 0.4
+max_layer_height = 0.3
+min_layer_height = 0.08
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_ULTIMAKER\nPRINTER_MODEL_ULTIMAKER2
+nozzle_diameter = 0.4
+default_print_profile = 0.20mm NORMAL @ULTIMAKER2
+default_filament_profile = Generic PLA @ULTIMAKER2
+start_gcode = start_gcode = ; Printer_Settings_ID: [printer_settings_id]\n\n; # # # # # # START Header\nG21 		; metric values\nG90 		; absolute positioning\nM82 		; set extruder to absolute mode\nM107 		; start with the fan off\n\nM140 S[first_layer_bed_temperature]	; start bed heating\n\nG28 X0 Y0 Z0	; move X/Y/Z to endstops\nG1 X1 Y6 F15000	; move X/Y to start position\nG1 Z35 F9000	; move Z to start position\n\n; Wait for bed and nozzle temperatures\nM190 S{first_layer_bed_temperature[0] - 5}	; wait for bed temperature - 5\nM140 S[first_layer_bed_temperature]	; continue bed heating\nM109 S[first_layer_temperature]	; wait for nozzle temperature\n\n; Purge and prime\nM83 		; set extruder to relative mode\nG92 E0           ; reset extrusion distance\nG0 X0 Y1 F10000\nG1 F150 E20 Y10  ; compress the bowden tube\nG1 E-8 F1200\nG0 X30 Y1 F5000    \nG0 F1200 Z{first_layer_height/2} ; Cut the connection to priming blob\nG0 X100 F10000 ; disconnect with the prime blob\nG0 X50         ; Avoid the metal clip holding the Ultimaker glass plate\nG0 Z0.2 F720\nG1 E8 F1200\nG1 X80 E3 F1000  ; intro line 1\nG1 X110 E4 F1000 ; intro line 2\nG1 X140 F600        ; drag filament to decompress bowden tube\nG1 X100 F3200       ; wipe backwards a bit\nG1 X150 F3200       ; back to where there is no plastic: avoid dragging\nG92 E0           ; reset extruder reference\nM82 		; set extruder to absolute mode\n\n; # # # # # # END Header
+end_gcode = ; # # # # # # START Footer\nG91 			; relative coordinates\n;G1 E-1 F1200		; retract the filament\nG1 Z+15  X-10 Y-10 E-7  F6000		; move Z a bit\n; G1 X-10 Y-10 F6000	; move XY a bit\nG1 E-5.5 F300		; retract the filament\nG28 X0 Y0		; move X/Y to min endstops, so the head is out of the way\nM104 S0			; extruder heater off\nM140 S0			; heated bed heater off (if you have it)\nM84 			; disable motors\n; # # # # # # END Footer\n


### PR DESCRIPTION
Still using a priming blob, because the amount of extrusion needed to start actually getting plastic out of the nozzle seemed unreliable. Probably because of possible retraction at the end of the previous print.

Then, a line like Prusaslicer does with (at least) the MK3S.

Here is a [video of how it looks like](https://youtu.be/PYDGeOXgxOc).
@foreachthing @rtyr 

I put that in a new file, I am not sure about versioning with file names. Here is the diff with the previous version, for convenience:

```
$ diff 1.0.0.ini 1.0.1.ini --color
12c12
< config_version = 1.0.0
---
> config_version = 1.0.1
399c399
< start_gcode = ; Printer_Settings_ID: [printer_settings_id]\n\n; # # # # # # START Header\nG21 	; metric values\nG90 		; absolute positioning\nM82 		; set extruder to absolute mode\nM107 		; start with the fan off\n\nG28 X0 Y0 Z0	; move X/Y/Z to endstops\nG1 X1 Y6 F15000; move X/Y to start position\nG1 Z35 F9000	; move Z to start position\n\n; Heat up bed and nozzle\nM190 S{first_layer_bed_temperature[0] - 5}	; wait for bed temperature - 5\nM140 S[first_layer_bed_temperature]	; continue bed heating\nM109 S[first_layer_temperature]	; wait for nozzle temperature\n\nG92 E0		; zero the extruded length\nG1 F150 E22	; purge nozzle with filament\nG92 E0		; zero the extruded length again\nG1 F75 E7	; additional priming\nG92 E0		; zero the extruded length again\n\n; # # # # # # END Header
---
> start_gcode = start_gcode = ; Printer_Settings_ID: [printer_settings_id]\n\n; # # # # # # START Header\nG21 		; metric values\nG90 		; absolute positioning\nM82 		; set extruder to absolute mode\nM107 		; start with the fan off\n\nM140 S[first_layer_bed_temperature]	; start bed heating\n\nG28 X0 Y0 Z0	; move X/Y/Z to endstops\nG1 X1 Y6 F15000	; move X/Y to start position\nG1 Z35 F9000	; move Z to start position\n\n; Wait for bed and nozzle temperatures\nM190 S{first_layer_bed_temperature[0] - 5}	; wait for bed temperature - 5\nM140 S[first_layer_bed_temperature]	; continue bed heating\nM109 S[first_layer_temperature]	; wait for nozzle temperature\n\n; Purge and prime\nM83 		; set extruder to relative mode\nG92 E0           ; reset extrusion distance\nG0 X0 Y1 F10000\nG1 F150 E20 Y10  ; compress the bowden tube\nG1 E-8 F1200\nG0 X30 Y1 F5000    \nG0 F1200 Z{first_layer_height/2} ; Cut the connection to priming blob\nG0 X100 F10000 ; disconnect with the prime blob\nG0 X50         ; Avoid the metal clip holding the Ultimaker glass plate\nG0 Z0.2 F720\nG1 E8 F1200\nG1 X80 E3 F1000  ; intro line 1\nG1 X110 E4 F1000 ; intro line 2\nG1 X140 F600        ; drag filament to decompress bowden tube\nG1 X100 F3200       ; wipe backwards a bit\nG1 X150 F3200       ; back to where there is no plastic: avoid dragging\nG92 E0           ; reset extruder reference\nM82 		; set extruder to absolute mode\n\n; # # # # # # END Header

```