### PR TITLE
TRILAB printing profiles update 1.0.1

### DIFF
--- a/live/TriLAB/1.0.1.ini
+++ b/live/TriLAB/1.0.1.ini
@@ -1,0 +1,1964 @@
+# Print profiles for the TriLAB printers
+# based on https://github.com/trilab3d/PrusaSlicer-settings/tree/master/live/TriLAB
+
+[vendor]
+# Vendor name will be shown by the Config Wizard.
+name = TriLAB
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the PrusaSlicer configuration to be downgraded.
+config_version = 1.0.1
+# Where to get the updates from?
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/TriLAB/
+# changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
+
+# The printer models will be shown by the Configuration Wizard in this order,
+# also the first model installed & the first nozzle installed will be activated after install.
+# Printer model name will be shown by the installation wizard.
+
+[printer_model:AQI]
+name = AzteQ Industrial
+variants = 0.4; 0.6; 0.8
+technology = FFF
+family = AzteQ
+bed_model = aq_bed.stl
+bed_texture = aq_bed_texture.svg
+default_materials = AzteQ Industrial (Door Opened) - PLA - ExtraFill (Fillamentum);AzteQ Industrial (Door Opened) - PLA - Generic;AzteQ Industrial (PLA Printhead) - PLA - ExtraFill (Fillamentum);AzteQ Industrial - ABS - ExtraFill (Fillamentum);AzteQ Industrial - ABS - Generic;AzteQ Industrial - ASA - ExtraFill (Fillamentum);AzteQ Industrial - ASA - Generic;AzteQ Industrial - ASA - Prusament (Prusa);AzteQ Industrial - PA - Nylon PA12 (Fiberlogy);AzteQ Industrial - PC Blend - Prusament (Prusa);AzteQ Industrial - PC - PolyMax (Polymaker);AzteQ Industrial - PC - PolyMax (Polymaker) @0.6 nozzle;AzteQ Industrial - PC/ABS - (Fillamentum);AzteQ Industrial - PC/ABS - (Fillamentum) @0.6 nozzle;AzteQ Industrial - PA - Nylon FX256 (Fillamentum);AzteQ Industrial - PA - Nylon FX256 (Fillamentum) @0.6 nozzle;AzteQ Industrial - ABS - Generic @0.8 nozzle;AzteQ Industrial - ABS - ExtraFill (Fillamentum) @0.8 nozzle;AzteQ Industrial - ASA - ExtraFill (Fillamentum) @0.8 nozzle;AzteQ Industrial - ASA - Prusament (Prusa) @0.8 nozzle;AzteQ Industrial - PC Blend - Prusament (Prusa) @0.8 nozzle
+
+[printer_model:DQ2]
+name = DeltiQ 2
+variants = 0.4; 0.25; 0.6; 0.8
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ - PLA - Generic;DeltiQ - PLA - ExtraFill (Fillamentum);DeltiQ - PETG - Generic;DeltiQ - PETG (Devil Design);DeltiQ - ABS - Generic;DeltiQ - ABS - ExtraFill (Fillamentum);DeltiQ - ASA - ExtraFill (Fillamentum);DeltiQ - ASA - ASA 275 (Spectrum);DeltiQ - CPE - HG100 (Fillamentum);DeltiQ - PLA - ExtraFill (Fillamentum) @0.25 nozzle;DeltiQ - PETG (Devil Design) @0.25 nozzle;DeltiQ - PLA - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - PETG (Devil Design) @0.6 nozzle;DeltiQ - ABS - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - ASA - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - ASA - ASA 275 (Spectrum) @0.6 nozzle;DeltiQ - CPE - HG100 (Fillamentum) @0.6 nozzle;DeltiQ - PLA - ExtraFill (Fillamentum) @0.8 nozzle;DeltiQ - PETG (Devil Design) @0.8 nozzle;DeltiQ - PA - Nylon PA12 (Fiberlogy);DeltiQ - PA - Nylon CF15 Carbon (Fillamentum);DeltiQ - MoldLay (Wax-Alike)
+
+[printer_model:DQ2P]
+name = DeltiQ 2 Plus
+variants = 0.4; 0.25; 0.6; 0.8
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ - PLA - Generic;DeltiQ - PLA - ExtraFill (Fillamentum);DeltiQ - PETG - Generic;DeltiQ - PETG (Devil Design);DeltiQ - ABS - Generic;DeltiQ - ABS - ExtraFill (Fillamentum);DeltiQ - ASA - ExtraFill (Fillamentum);DeltiQ - ASA - ASA 275 (Spectrum);DeltiQ - CPE - HG100 (Fillamentum);DeltiQ - PLA - ExtraFill (Fillamentum) @0.25 nozzle;DeltiQ - PETG (Devil Design) @0.25 nozzle;DeltiQ - PLA - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - PETG (Devil Design) @0.6 nozzle;DeltiQ - ABS - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - ASA - ExtraFill (Fillamentum) @0.6 nozzle;DeltiQ - ASA - ASA 275 (Spectrum) @0.6 nozzle;DeltiQ - CPE - HG100 (Fillamentum) @0.6 nozzle;DeltiQ - PLA - ExtraFill (Fillamentum) @0.8 nozzle;DeltiQ - PETG (Devil Design) @0.8 nozzle;DeltiQ - PA - Nylon PA12 (Fiberlogy);DeltiQ - PA - Nylon CF15 Carbon (Fillamentum);DeltiQ - MoldLay (Wax-Alike)
+
+[printer_model:DQ2+FP2]
+name = DeltiQ 2 + FlexPrint 2
+variants = 0.4
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ FP2 - PLA - Generic;DeltiQ FP2 - PLA - ExtraFill (Fillamentum);DeltiQ FP2 - PETG - Generic;DeltiQ FP2 - PETG (Devil Design);DeltiQ FP2 - ABS - Generic;DeltiQ FP2 - ABS - ExtraFill (Fillamentum);DeltiQ FP2 - ASA - ExtraFill (Fillamentum);DeltiQ FP2 - CPE - HG100 (Fillamentum);DeltiQ FP2 - FLEX - Generic;DeltiQ FP2 - TPU 92A - FlexFill (Fillamentum);DeltiQ FP2 - TPU 98A - FlexFill (Fillamentum);DeltiQ FP2 - TPU 93A (SMARTFIL);DeltiQ FP2 - PEBA 90A - FlexFill (Fillamentum)
+
+[printer_model:DQ2P+FP2]
+name = DeltiQ 2 Plus + FlexPrint 2
+variants = 0.4
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ FP2 - PLA - Generic;DeltiQ FP2 - PLA - ExtraFill (Fillamentum);DeltiQ FP2 - PETG - Generic;DeltiQ FP2 - PETG (Devil Design);DeltiQ FP2 - ABS - Generic;DeltiQ FP2 - ABS - ExtraFill (Fillamentum);DeltiQ FP2 - ASA - ExtraFill (Fillamentum);DeltiQ FP2 - CPE - HG100 (Fillamentum);DeltiQ FP2 - FLEX - Generic;DeltiQ FP2 - TPU 92A - FlexFill (Fillamentum);DeltiQ FP2 - TPU 98A - FlexFill (Fillamentum);DeltiQ FP2 - TPU 93A (SMARTFIL);DeltiQ FP2 - PEBA 90A - FlexFill (Fillamentum)
+
+[printer_model:DQ2+FP]
+name = DeltiQ 2 + FlexPrint
+variants = 0.4
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ FP - PLA - Generic;DeltiQ FP - PLA - ExtraFill (Fillamentum);DeltiQ FP - PETG - Generic;DeltiQ FP - PETG (Devil Design);DeltiQ FP - ABS - Generic;DeltiQ FP - ABS - ExtraFill (Fillamentum);DeltiQ FP - ASA - ExtraFill (Fillamentum);DeltiQ FP - CPE - HG100 (Fillamentum);DeltiQ FP - FLEX - Generic
+
+[printer_model:DQ2P+FP]
+name = DeltiQ 2 Plus + FlexPrint
+variants = 0.4
+technology = FFF
+family = DeltiQ 2
+bed_model = dq2_bed.stl
+bed_texture = dq2_bed_texture.svg
+default_materials = DeltiQ FP - PLA - Generic;DeltiQ FP - PLA - ExtraFill (Fillamentum);DeltiQ FP - PETG - Generic;DeltiQ FP - PETG (Devil Design);DeltiQ FP - ABS - Generic;DeltiQ FP - ABS - ExtraFill (Fillamentum);DeltiQ FP - ASA - ExtraFill (Fillamentum);DeltiQ FP - CPE - HG100 (Fillamentum);DeltiQ FP - FLEX - Generic
+
+[printer_model:DQM]
+name = DeltiQ M
+variants = 0.4
+technology = FFF
+family = DeltiQ
+default_materials = DeltiQ PLA; DeltiQ ASA; DeltiQ PET; DeltiQ ABS; DeltiQ CPE
+
+[printer_model:DQL]
+name = DeltiQ L
+variants = 0.4
+technology = FFF
+family = DeltiQ
+default_materials = DeltiQ PLA; DeltiQ ASA; DeltiQ PET; DeltiQ ABS; DeltiQ CPE
+
+[printer_model:DQXL]
+name = DeltiQ XL
+variants = 0.4
+technology = FFF
+family = DeltiQ
+default_materials = DeltiQ PLA; DeltiQ ASA; DeltiQ PET; DeltiQ ABS; DeltiQ CPE
+
+# DeltiQ print styles #
+
+[print:DeltiQ 0.20mm Normal]
+avoid_crossing_perimeters = 0
+bottom_fill_pattern = monotonic
+bottom_solid_layers = 4
+bottom_solid_min_thickness = 0.7
+bridge_acceleration = 1000
+bridge_angle = 0
+bridge_flow_ratio = 0.95
+bridge_speed = 30
+brim_width = 0
+clip_multipart_objects = 1
+compatible_printers = 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and nozzle_diameter[0]==0.4
+complete_objects = 0
+default_acceleration = 2000
+dont_support_bridges = 0
+draft_shield = 0
+elefant_foot_compensation = 0.1
+ensure_vertical_shell_thickness = 0
+external_perimeter_extrusion_width = 0.45
+external_perimeter_speed = 30
+external_perimeters_first = 0
+extra_perimeters = 0
+extruder_clearance_height = 60
+extruder_clearance_radius = 45
+extrusion_width = 0.45
+fill_angle = 45
+fill_density = 20%
+fill_pattern = grid
+first_layer_acceleration = 1000
+first_layer_extrusion_width = 0.42
+first_layer_height = 0.2
+first_layer_speed = 20
+gap_fill_speed = 40
+gcode_comments = 0
+gcode_label_objects = 0
+infill_acceleration = 2000
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.45
+infill_first = 0
+infill_only_where_needed = 0
+infill_overlap = 25%
+infill_speed = 60
+interface_shells = 0
+ironing = 0
+ironing_flowrate = 15%
+ironing_spacing = 0.1
+ironing_speed = 15
+ironing_type = top
+layer_height = 0.2
+max_print_speed = 60
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+only_retract_when_crossing_perimeters = 0
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{printer_model}_{filament_type[0]}_{layer_height}mm_{print_time}_{timestamp}.gcode
+overhangs = 1
+perimeter_acceleration = 1500
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.45
+perimeter_speed = 45
+perimeters = 2
+post_process = 
+print_settings_id = 
+raft_layers = 0
+resolution = 0
+seam_position = nearest
+single_extruder_multi_material_priming = 0
+skirt_distance = 3
+skirt_height = 2
+skirts = 1
+slice_closing_radius = 0.049
+small_perimeter_speed = 20
+solid_infill_below_area = 70
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.45
+solid_infill_speed = 60
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 0
+support_material_angle = 30
+support_material_auto = 1
+support_material_buildplate_only = 0
+support_material_contact_distance = 0.1
+support_material_enforce_layers = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.35
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 0
+support_material_interface_layers = 4
+support_material_interface_spacing = 0.4
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 50
+support_material_synchronize_layers = 0
+support_material_threshold = 40
+support_material_with_sheath = 0
+support_material_xy_spacing = 0.6
+thin_walls = 0
+threads = 12
+top_fill_pattern = monotonic
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 40
+top_solid_layers = 5
+top_solid_min_thickness = 0.7
+travel_speed = 150
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_no_sparse_layers = 0
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 180
+wipe_tower_y = 140
+xy_size_compensation = 0
+
+[print:DeltiQ 0.10mm Detail]
+inherits = DeltiQ 0.20mm Normal
+bottom_solid_layers = 7
+bottom_solid_min_thickness = 0.7
+bridge_flow_ratio = 0.7
+bridge_speed = 30
+ensure_vertical_shell_thickness = 1
+layer_height = 0.1
+first_layer_height = 0.2
+top_solid_layers = 9
+top_solid_min_thickness = 0.7
+top_infill_extrusion_width = 0.4
+fill_pattern = grid
+fill_density = 20%
+
+[print:DeltiQ 0.15mm Normal]
+inherits = DeltiQ 0.20mm Normal
+bottom_solid_layers = 5
+bottom_solid_min_thickness = 0.7
+bridge_flow_ratio = 0.7
+bridge_speed = 30
+ensure_vertical_shell_thickness = 1
+layer_height = 0.15
+first_layer_height = 0.2
+top_solid_layers = 7
+top_solid_min_thickness = 0.7
+fill_pattern = grid
+fill_density = 20%
+
+[print:DeltiQ 0.20mm Vase]
+inherits = DeltiQ 0.20mm Normal
+perimeters = 1
+top_solid_layers = 0
+fill_density = 0
+support_material = 0
+spiral_vase = 1
+ensure_vertical_shell_thickness = 1
+thin_walls = 0
+
+[print:DeltiQ 0.20mm FLEX]
+inherits = DeltiQ 0.20mm Normal
+avoid_crossing_perimeters = 0
+bridge_flow_ratio = 0.80
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT.*/ and nozzle_diameter[0]==0.4
+extra_perimeters = 1
+only_retract_when_crossing_perimeters = 1
+extrusion_width = 0.40
+overhangs = 0
+seam_position = nearest
+thin_walls = 0
+bridge_speed = 20
+external_perimeter_speed = 20
+first_layer_speed = 20
+gap_fill_speed = 25
+infill_extrusion_width = 0.55
+infill_speed = 40
+infill_overlap = 27%
+perimeter_speed = 25
+small_perimeter_speed = 20
+solid_infill_speed = 30
+solid_infill_extrusion_width = 0.45
+support_material_contact_distance = 0.3
+support_material_speed = 30
+top_solid_infill_speed = 20
+top_fill_pattern = rectilinear
+fill_pattern = grid
+fill_density = 25%
+travel_speed = 200
+max_print_speed = 40
+complete_objects = 1
+
+[print:DeltiQ 0.07mm Quality @0.25 nozzle]
+inherits = DeltiQ 0.20mm Normal
+bottom_solid_layers = 6
+bottom_solid_min_thickness = 0.5
+bridge_speed = 60
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and nozzle_diameter[0]==0.25
+elefant_foot_compensation = 0.0
+external_perimeter_extrusion_width = 0.27
+extrusion_width = 0.25
+first_layer_extrusion_width = 0.26
+first_layer_height = 0.1
+infill_extrusion_width = 0.27
+infill_overlap = 50%
+layer_height = 0.07
+overhangs = 1
+perimeter_extrusion_width = 0.27
+perimeters = 5
+solid_infill_extrusion_width = 0.27
+skirts = 2
+support_material_extrusion_width = 0.27
+support_material_contact_distance = 0.1
+top_infill_extrusion_width = 0.27
+top_solid_layers = 6
+top_solid_min_thickness = 0.5
+thin_walls = 1
+
+[print:DeltiQ 0.20mm Normal @0.25 nozzle]
+inherits = DeltiQ 0.07mm Quality @0.25 nozzle
+first_layer_height = 0.2
+layer_height = 0.2
+
+[print:DeltiQ 0.30mm Normal @0.6 nozzle]
+inherits = DeltiQ 0.20mm Normal
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and nozzle_diameter[0]==0.6
+external_perimeter_extrusion_width = 0.68
+extrusion_width = 0.65
+first_layer_extrusion_width = 0.65
+first_layer_height = 0.3
+infill_extrusion_width = 0.68
+layer_height = 0.3
+perimeter_extrusion_width = 0.68
+solid_infill_extrusion_width = 0.68
+support_material_contact_distance = 0.2
+support_material_extrusion_width = 0.55
+support_material_interface_spacing = 0.6
+support_material_xy_spacing = 0.9
+top_infill_extrusion_width = 0.6
+elefant_foot_compensation = 0.2
+
+[print:DeltiQ 0.30mm Strong @0.6 nozzle]
+inherits = DeltiQ 0.30mm Normal @0.6 nozzle
+fill_density = 50%
+perimeters = 3
+
+[print:DeltiQ 0.35mm Fast @0.6 nozzle]
+inherits = DeltiQ 0.30mm Normal @0.6 nozzle
+fill_density = 10%
+layer_height = 0.35
+
+[print:DeltiQ 0.40mm Normal @0.8 nozzle]
+inherits = DeltiQ 0.20mm Normal
+bottom_solid_layers = 3
+bottom_solid_min_thickness = 1.2
+bridge_flow_ratio = 0.90
+bridge_speed = 20
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and nozzle_diameter[0]==0.8
+elefant_foot_compensation = 0.2
+external_perimeter_extrusion_width = 0.80
+external_perimeter_speed = 30
+extrusion_width = 0.80
+first_layer_extrusion_width = 0.80
+first_layer_height = 0.4
+first_layer_speed = 20
+gap_fill_speed = 40
+infill_extrusion_width = 0.9
+infill_overlap = 28%
+infill_speed = 60
+layer_height = 0.4
+max_print_speed = 80
+max_volumetric_speed = 40
+overhangs = 1
+perimeter_extrusion_width = 0.80
+perimeter_speed = 45
+perimeters = 2
+small_perimeter_speed = 20
+solid_infill_extrusion_width = 0.8
+solid_infill_speed = 60
+support_material_extrusion_width = 0.8
+support_material_contact_distance = 0.2
+top_infill_extrusion_width = 0.8
+top_solid_infill_speed = 40
+top_solid_layers = 4
+top_solid_min_thickness = 1.2
+
+[print:DeltiQ 0.40mm Vase @0.8 nozzle]
+inherits = DeltiQ 0.40mm Normal @0.8 nozzle
+bottom_solid_layers = 4
+perimeters = 1
+top_solid_layers = 0
+fill_density = 0
+support_material = 0
+spiral_vase = 1
+ensure_vertical_shell_thickness = 1
+thin_walls = 0
+
+# AzteQ print styles #
+
+[print:AzteQ Industrial 0.20mm Normal]
+avoid_crossing_perimeters = 0
+avoid_crossing_perimeters_max_detour = 0
+bottom_fill_pattern = monotonic
+bottom_solid_layers = 4
+bottom_solid_min_thickness = 0.7
+bridge_acceleration = 1000
+bridge_angle = 0
+bridge_flow_ratio = 0.95
+bridge_speed = 30
+brim_width = 0
+clip_multipart_objects = 1
+compatible_printers = 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.4
+complete_objects = 0
+default_acceleration = 2000
+dont_support_bridges = 0
+draft_shield = 0
+elefant_foot_compensation = 0.1
+ensure_vertical_shell_thickness = 0
+external_perimeter_extrusion_width = 0.45
+external_perimeter_speed = 30
+external_perimeters_first = 0
+extra_perimeters = 0
+extruder_clearance_height = 65
+extruder_clearance_radius = 65
+extrusion_width = 0.45
+fill_angle = 45
+fill_density = 20%
+fill_pattern = grid
+first_layer_acceleration = 1000
+first_layer_extrusion_width = 0.42
+first_layer_height = 0.2
+first_layer_speed = 20
+gap_fill_speed = 40
+gcode_comments = 0
+gcode_label_objects = 0
+infill_acceleration = 2000
+infill_anchor = 600%
+infill_anchor_max = 50
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.45
+infill_first = 0
+infill_only_where_needed = 0
+infill_overlap = 25%
+infill_speed = 60
+inherits = 
+interface_shells = 0
+ironing = 0
+ironing_flowrate = 15%
+ironing_spacing = 0.1
+ironing_speed = 15
+ironing_type = top
+layer_height = 0.2
+max_print_speed = 60
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+only_retract_when_crossing_perimeters = 0
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{printer_model}_{filament_type[0]}_{layer_height}mm_{print_time}_{timestamp}.gcode
+overhangs = 1
+perimeter_acceleration = 1500
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.45
+perimeter_speed = 45
+perimeters = 2
+post_process = 
+print_settings_id = 
+raft_layers = 0
+resolution = 0
+seam_position = nearest
+single_extruder_multi_material_priming = 0
+skirt_distance = 10
+skirt_height = 2
+skirts = 1
+slice_closing_radius = 0.049
+small_perimeter_speed = 20
+solid_infill_below_area = 70
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.45
+solid_infill_speed = 60
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 0
+support_material_angle = 30
+support_material_auto = 1
+support_material_buildplate_only = 0
+support_material_contact_distance = 0.1
+support_material_enforce_layers = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.35
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 0
+support_material_interface_layers = 4
+support_material_interface_spacing = 0.4
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 50
+support_material_synchronize_layers = 0
+support_material_threshold = 40
+support_material_with_sheath = 0
+support_material_xy_spacing = 0.6
+thin_walls = 0
+threads = 12
+top_fill_pattern = monotonic
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 40
+top_solid_layers = 5
+top_solid_min_thickness = 0.7
+travel_speed = 200
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_no_sparse_layers = 0
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 180
+wipe_tower_y = 140
+xy_size_compensation = 0
+
+[print:AzteQ Industrial 0.15mm Detail]
+inherits = AzteQ Industrial 0.20mm Normal
+layer_height = 0.15
+
+[print:AzteQ Industrial 0.20mm Strong]
+inherits = AzteQ Industrial 0.20mm Normal
+fill_density = 50%
+perimeters = 3
+
+[print:AzteQ Industrial 0.20mm Vase]
+inherits = AzteQ Industrial 0.20mm Normal
+ensure_vertical_shell_thickness = 1
+fill_density = 0%
+perimeters = 1
+spiral_vase = 1
+top_solid_layers = 0
+
+[print:AzteQ Industrial 0.25mm Fast]
+inherits = AzteQ Industrial 0.20mm Normal
+fill_density = 10%
+layer_height = 0.25
+
+[print:AzteQ Industrial 0.30mm Normal @0.6 nozzle]
+inherits = AzteQ Industrial 0.20mm Normal
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+external_perimeter_extrusion_width = 0.68
+extrusion_width = 0.65
+first_layer_extrusion_width = 0.65
+first_layer_height = 0.3
+infill_extrusion_width = 0.68
+layer_height = 0.3
+perimeter_extrusion_width = 0.68
+solid_infill_extrusion_width = 0.68
+support_material_contact_distance = 0.2
+support_material_extrusion_width = 0.55
+support_material_interface_spacing = 0.6
+support_material_xy_spacing = 0.9
+top_infill_extrusion_width = 0.6
+elefant_foot_compensation = 0.2
+
+[print:AzteQ Industrial 0.30mm Strong @0.6 nozzle]
+inherits = AzteQ Industrial 0.30mm Normal @0.6 nozzle
+fill_density = 50%
+perimeters = 3
+
+[print:AzteQ Industrial 0.35mm Fast @0.6 nozzle]
+inherits = AzteQ Industrial 0.30mm Normal @0.6 nozzle
+fill_density = 10%
+layer_height = 0.35
+
+[print:AzteQ Industrial 0.40mm Normal @0.8 nozzle]
+inherits = AzteQ Industrial 0.20mm Normal
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+avoid_crossing_perimeters = 0
+avoid_crossing_perimeters_max_detour = 0
+bottom_solid_layers = 4
+bottom_solid_min_thickness = 0.7
+bridge_flow_ratio = 0.95
+bridge_speed = 30
+dont_support_bridges = 0
+elefant_foot_compensation = 0.2
+ensure_vertical_shell_thickness = 0
+external_perimeter_extrusion_width = 0.8
+external_perimeter_speed = 30
+external_perimeters_first = 0
+extra_perimeters = 0
+extrusion_width = 0.8
+fill_angle = 45
+fill_density = 20%
+fill_pattern = grid
+first_layer_extrusion_width = 0.8
+first_layer_height = 0.4
+first_layer_speed = 20
+first_layer_speed_over_raft = 30
+gap_fill_enabled = 1
+gap_fill_speed = 40
+infill_extrusion_width = 0.8
+infill_first = 0
+infill_overlap = 25%
+infill_speed = 60
+layer_height = 0.4
+max_print_speed = 60
+max_volumetric_speed = 0
+only_retract_when_crossing_perimeters = 1
+overhangs = 1
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.8
+perimeter_speed = 45
+perimeters = 2
+raft_contact_distance = 0.1
+raft_expansion = 1.5
+raft_first_layer_density = 90%
+raft_first_layer_expansion = 3
+raft_layers = 0
+skirt_distance = 10
+skirt_height = 2
+skirts = 1
+small_perimeter_speed = 20
+solid_infill_below_area = 70
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.8
+solid_infill_speed = 60
+support_material = 0
+support_material_angle = 30
+support_material_auto = 1
+support_material_bottom_contact_distance = 0
+support_material_bottom_interface_layers = -1
+support_material_buildplate_only = 0
+support_material_closing_radius = 2
+support_material_contact_distance = 0.1
+support_material_enforce_layers = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.8
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 0
+support_material_interface_layers = 4
+support_material_interface_pattern = auto
+support_material_interface_spacing = 0.4
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 50
+support_material_style = grid
+support_material_synchronize_layers = 0
+support_material_threshold = 40
+support_material_with_sheath = 0
+support_material_xy_spacing = 0.6
+thick_bridges = 1
+thin_walls = 0
+threads = 12
+top_fill_pattern = monotonic
+top_infill_extrusion_width = 0.8
+top_solid_infill_speed = 40
+top_solid_layers = 5
+top_solid_min_thickness = 0.7
+travel_speed = 200
+travel_speed_z = 0
+
+[print:AzteQ Industrial 0.40mm Vase @0.8 nozzle]
+inherits = AzteQ Industrial 0.40mm Normal @0.8 nozzle
+bottom_solid_layers = 4
+perimeters = 1
+top_solid_layers = 0
+fill_density = 0
+support_material = 0
+spiral_vase = 1
+ensure_vertical_shell_thickness = 1
+thin_walls = 0
+
+# DeltiQ filaments #
+
+[filament:*DeltiQ common*]
+compatible_printers = 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.4
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+filament_colour = #FF0000
+filament_diameter = 1.75
+filament_minimal_purge_on_wipe_tower = 15
+filament_notes = ""
+filament_ramming_parameters = "120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_settings_id = ""
+filament_soluble = 0
+filament_toolchange_delay = 0
+start_filament_gcode = "; FILAMENT_START_GCODE"
+end_filament_gcode = "; FILAMENT_END_GCODE"
+filament_cost = 0
+filament_spool_weight = 250
+filament_vendor = Generic
+
+# DeltiQ PLA filaments #
+
+[filament:DeltiQ - PLA - Generic]
+inherits = *DeltiQ common* 
+bed_temperature = 55
+bridge_fan_speed = 100
+cooling = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_density = 1.24
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 90%
+filament_retract_layer_change = 1
+filament_retract_length = 4.0
+filament_retract_lift = 0.2
+filament_retract_speed = 30
+filament_type = PLA
+filament_wipe = 1
+first_layer_bed_temperature = 55
+first_layer_temperature = 220
+max_fan_speed = 100
+min_fan_speed = 100
+min_print_speed = 10
+slowdown_below_layer_time = 4
+temperature = 215
+
+[filament:DeltiQ - PLA - ExtraFill (Fillamentum)]
+inherits = DeltiQ - PLA - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.24
+filament_vendor = Fillamentum
+
+[filament:DeltiQ - PLA - ExtraFill (Fillamentum) @0.25 nozzle]
+inherits = DeltiQ - PLA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.25
+
+[filament:DeltiQ - PLA - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = DeltiQ - PLA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:DeltiQ - PLA - ExtraFill (Fillamentum) @0.8 nozzle]
+inherits = DeltiQ - PLA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.8
+disable_fan_first_layers = 1
+filament_max_volumetric_speed = 40
+first_layer_temperature = 230
+slowdown_below_layer_time = 8
+temperature = 230
+filament_retract_layer_change = 0
+filament_retract_length = 4.1
+filament_retract_speed = 45
+filament_deretract_speed = 25
+
+[filament:DeltiQ FP - PLA - Generic]
+inherits = DeltiQ - PLA - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.7
+filament_retract_speed = 28
+
+[filament:DeltiQ FP - PLA - ExtraFill (Fillamentum)]
+inherits = DeltiQ FP - PLA - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.24
+filament_vendor = Fillamentum
+
+[filament:DeltiQ FP2 - PLA - Generic]
+inherits = DeltiQ FP - PLA - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 1.2
+filament_retract_speed = 28
+
+[filament:DeltiQ FP2 - PLA - ExtraFill (Fillamentum)]
+inherits = DeltiQ FP2 - PLA - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.24
+filament_vendor = Fillamentum
+
+# DeltiQ PETG filaments #
+
+[filament:DeltiQ - PETG - Generic]
+inherits = *DeltiQ common* 
+bed_temperature = 80
+bridge_fan_speed = 50
+cooling = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.27
+filament_deretract_speed = 25
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_speed = 45
+filament_type = PET
+filament_wipe = 1
+first_layer_bed_temperature = 80
+first_layer_temperature = 240
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 10
+slowdown_below_layer_time = 5
+temperature = 245
+
+[filament:DeltiQ - PETG (Devil Design)]
+inherits = DeltiQ - PETG - Generic
+filament_cost = 16.53
+filament_spool_weight = 247
+filament_density = 1.27
+filament_vendor = DevilDesign
+
+[filament:DeltiQ - PETG (Devil Design) @0.25 nozzle]
+inherits = DeltiQ - PETG (Devil Design)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.25
+first_layer_temperature = 225
+temperature = 220
+max_fan_speed = 65
+min_fan_speed = 40
+bridge_fan_speed = 100
+
+[filament:DeltiQ - PETG (Devil Design) @0.6 nozzle]
+inherits = DeltiQ - PETG (Devil Design)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:DeltiQ - PETG (Devil Design) @0.8 nozzle]
+inherits = DeltiQ - PETG (Devil Design)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.8
+filament_max_volumetric_speed = 40
+first_layer_temperature = 240
+slowdown_below_layer_time = 8
+temperature = 240
+filament_retract_layer_change = 0
+filament_retract_length = 4.3
+filament_retract_speed = 45
+filament_deretract_speed = 25
+filament_retract_before_wipe = 80%
+filament_wipe = 1
+
+[filament:DeltiQ FP - PETG - Generic]
+inherits = DeltiQ - PETG - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.7
+filament_retract_speed = 25
+
+[filament:DeltiQ FP - PETG (Devil Design)]
+inherits = DeltiQ FP - PETG - Generic
+filament_cost = 16.53
+filament_spool_weight = 247
+filament_density = 1.27
+filament_vendor = DevilDesign
+
+[filament:DeltiQ FP2 - PETG - Generic]
+inherits = DeltiQ FP - PETG - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 1.4
+filament_retract_speed = 35
+filament_retract_before_wipe = 0%
+
+[filament:DeltiQ FP2 - PETG (Devil Design)]
+inherits = DeltiQ FP2 - PETG - Generic
+filament_cost = 16.53
+filament_spool_weight = 247
+filament_density = 1.27
+filament_vendor = DevilDesign
+
+# DeltiQ ABS filaments #
+
+[filament:DeltiQ - ABS - Generic]
+inherits = *DeltiQ common* 
+bed_temperature = 100
+bridge_fan_speed = 25
+cooling = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.04
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_speed = 25
+filament_type = ABS
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 15
+min_fan_speed = 5
+min_print_speed = 10
+slowdown_below_layer_time = 15
+temperature = 255
+
+[filament:DeltiQ - ABS - ExtraFill (Fillamentum)]
+inherits = DeltiQ - ABS - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.04
+filament_vendor = Fillamentum
+
+[filament:DeltiQ - ABS - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = DeltiQ - ABS - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:DeltiQ FP - ABS - Generic]
+inherits = DeltiQ - ABS - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.7
+filament_retract_speed = 25
+
+[filament:DeltiQ FP - ABS - ExtraFill (Fillamentum)]
+inherits = DeltiQ FP - ABS - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.04
+filament_vendor = Fillamentum
+
+[filament:DeltiQ FP2 - ABS - Generic]
+inherits = DeltiQ FP - ABS - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.8
+filament_retract_speed = 25
+
+[filament:DeltiQ FP2 - ABS - ExtraFill (Fillamentum)]
+inherits = DeltiQ FP2 - ABS - Generic
+filament_cost = 24.27
+filament_spool_weight = 229
+filament_density = 1.04
+filament_vendor = Fillamentum
+
+
+# DeltiQ ASA filaments #
+
+[filament:DeltiQ - ASA - ExtraFill (Fillamentum)]
+inherits = DeltiQ - ABS - Generic
+filament_cost = 29.53
+filament_spool_weight = 229
+filament_density = 1.07
+filament_type = ASA
+filament_vendor = Fillamentum
+first_layer_temperature = 265
+temperature = 265
+
+[filament:DeltiQ - ASA - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = DeltiQ - ASA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:DeltiQ FP - ASA - ExtraFill (Fillamentum)]
+inherits = DeltiQ - ASA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.7
+filament_retract_speed = 25
+
+[filament:DeltiQ FP2 - ASA - ExtraFill (Fillamentum)]
+inherits = DeltiQ FP - ASA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+
+
+[filament:DeltiQ - ASA - ASA 275 (Spectrum)]
+inherits = *DeltiQ common* 
+bed_temperature = 55
+bridge_fan_speed = 80
+cooling = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_vendor = Spectrum
+filament_cost = 29.86
+filament_density = 1.07
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.3
+filament_retract_speed = 25
+filament_type = ASA
+filament_wipe = 1
+first_layer_bed_temperature = 55
+first_layer_temperature = 230
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 10
+slowdown_below_layer_time = 15
+temperature = 230
+
+[filament:DeltiQ - ASA - ASA 275 (Spectrum) @0.6 nozzle]
+inherits = DeltiQ - ASA - ASA 275 (Spectrum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+
+# DeltiQ CPE filaments #
+
+[filament:DeltiQ - CPE - HG100 (Fillamentum)]
+inherits = *DeltiQ common* 
+bed_temperature = 90
+bridge_fan_speed = 50
+cooling = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_vendor = Fillamentum
+filament_cost = 39.07
+filament_spool_weight = 229
+filament_density = 1.25
+filament_deretract_speed = 25
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 0
+filament_retract_length = 4.3
+filament_retract_lift = 0.2
+filament_retract_speed = 45
+filament_type = CPE
+filament_wipe = 1
+first_layer_bed_temperature = 90
+first_layer_temperature = 265
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 10
+slowdown_below_layer_time = 5
+temperature = 260
+
+[filament:DeltiQ - CPE - HG100 (Fillamentum) @0.6 nozzle]
+inherits = DeltiQ - CPE - HG100 (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_DQ.*/ and !(printer_notes=~/.*FLEXPRINT.*/) and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:DeltiQ FP - CPE - HG100 (Fillamentum)]
+inherits = DeltiQ - CPE - HG100 (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.7
+filament_retract_speed = 25
+filament_deretract_speed = 0
+filament_retract_before_wipe = 0%
+
+[filament:DeltiQ FP2 - CPE - HG100 (Fillamentum)]
+inherits = DeltiQ FP - CPE - HG100 (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+filament_retract_length = 0.8
+filament_retract_speed = 35
+filament_deretract_speed = 0
+filament_retract_before_wipe = 0%
+
+
+# DeltiQ FLEX filaments #
+
+[filament:DeltiQ FP - FLEX - Generic]
+inherits = *DeltiQ common*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT1.*/ and nozzle_diameter[0]==0.4
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 1
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.07
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.22
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3.0
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 0
+filament_retract_length = 2.5
+filament_retract_lift = 0.2
+filament_retract_restart_extra = nil
+filament_retract_speed = 20
+filament_type = FLEX
+filament_wipe = 1
+first_layer_bed_temperature = 50
+first_layer_temperature = 240
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 5
+slowdown_below_layer_time = 4
+temperature = 240
+
+[filament:DeltiQ FP2 - FLEX - Generic]
+inherits = DeltiQ FP - FLEX - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_FAMILY_DQ.*/ and printer_notes=~/.*FLEXPRINT2.*/ and nozzle_diameter[0]==0.4
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 1
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.07
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.22
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3.0
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 0
+filament_retract_length = 2.5
+filament_retract_lift = 0.2
+filament_retract_restart_extra = nil
+filament_retract_speed = 20
+filament_type = FLEX
+filament_wipe = 1
+first_layer_bed_temperature = 50
+first_layer_temperature = 225
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 5
+slowdown_below_layer_time = 4
+temperature = 225
+
+[filament:DeltiQ FP2 - TPU 92A - FlexFill (Fillamentum)]
+inherits = DeltiQ FP2 - FLEX - Generic
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 1
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.10
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_vendor = Fillamentum
+filament_cost = 58.33
+filament_spool_weight = 229
+filament_density = 1.22
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3.0
+filament_retract_before_travel = 2
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 0
+filament_retract_length = 2.5
+filament_retract_lift = 0.2
+filament_retract_restart_extra = nil
+filament_retract_speed = 20
+filament_type = TPU92A
+filament_wipe = 1
+first_layer_bed_temperature = 50
+first_layer_temperature = 230
+max_fan_speed = 70
+min_fan_speed = 50
+min_print_speed = 5
+slowdown_below_layer_time = 4
+temperature = 230
+
+[filament:DeltiQ FP2 - TPU 98A - FlexFill (Fillamentum)]
+inherits = DeltiQ FP2 - TPU 92A - FlexFill (Fillamentum)
+extrusion_multiplier = 1.10
+filament_cost = 58.33
+filament_spool_weight = 229
+filament_density = 1.23
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3.0
+filament_retract_before_wipe = 70%
+filament_retract_length = 2.5
+filament_retract_speed = 20
+filament_type = TPU98A
+
+[filament:DeltiQ FP2 - TPU 93A (SMARTFIL)]
+inherits = DeltiQ FP2 - FLEX - Generic
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1.00
+fan_always_on = 1
+fan_below_layer_time = 10
+filament_vendor = Smartfil
+filament_cost = 38.21
+filament_spool_weight = 250
+filament_density = 1.21
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 2.5
+filament_retract_before_travel = 2
+filament_retract_before_wipe = nil
+filament_retract_layer_change = 0
+filament_retract_length = 2.9
+filament_retract_lift = 0.2
+filament_retract_restart_extra = nil
+filament_retract_speed = 35
+filament_type = TPU93A
+filament_wipe = 0
+first_layer_bed_temperature = 50
+first_layer_temperature = 235
+max_fan_speed = 70
+min_fan_speed = 30
+min_print_speed = 10
+slowdown_below_layer_time = 4
+temperature = 235
+
+[filament:DeltiQ FP2 - PEBA 90A - FlexFill (Fillamentum)]
+inherits = DeltiQ FP2 - TPU 98A - FlexFill (Fillamentum)
+extrusion_multiplier = 1.1
+filament_cost = 139.67
+filament_spool_weight = 229
+filament_density = 1.00
+filament_max_volumetric_speed = 2.9
+filament_retract_length = 0.0
+filament_type = PEBA90A
+bridge_fan_speed = 100
+max_fan_speed = 50
+min_fan_speed = 50
+disable_fan_first_layers = 2
+first_layer_bed_temperature = 75
+first_layer_temperature = 245
+bed_temperature = 75
+temperature = 245
+
+[filament:DeltiQ - PA - Nylon PA12 (Fiberlogy)]
+inherits = DeltiQ - ABS - Generic
+bed_temperature = 100
+filament_cost = 45.11
+filament_spool_weight = 230
+filament_density = 1.02
+filament_retract_length = 4.1
+filament_type = NYLON
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 30
+min_fan_speed = 20
+temperature = 255
+
+[filament:DeltiQ - PA - Nylon CF15 Carbon (Fillamentum)]
+inherits = DeltiQ - ABS - Generic
+bed_temperature = 100
+filament_cost = 88.17
+filament_density = 1.08
+filament_spool_weight = 229
+filament_retract_length = 2.0
+filament_type = NYLON
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 50
+min_fan_speed = 20
+temperature = 255
+extrusion_multiplier = 0.95
+
+[filament:DeltiQ - MoldLay (Wax-Alike)]
+inherits = DeltiQ - PLA - Generic
+bed_temperature = 50
+filament_cost = 79.07
+filament_spool_weight = 230
+filament_retract_length = 2.0
+filament_type = PLA
+first_layer_bed_temperature = 50
+first_layer_temperature = 175
+max_fan_speed = 70
+min_fan_speed = 70
+temperature = 175
+filament_vendor = Wax-Alike
+
+
+# AzteQ filaments #
+
+[filament:*AzteQ common*]
+inherits = *DeltiQ common* 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.4
+
+# AzteQ Industrial filaments #
+
+[filament:AzteQ Industrial (Door Opened) - PLA - Generic]
+inherits = *AzteQ common* 
+bed_temperature = 50
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.24
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_spool_weight = 0
+filament_toolchange_delay = 0
+filament_type = PLA
+filament_vendor = Generic
+filament_wipe = 1
+first_layer_bed_temperature = 50
+first_layer_temperature = 215
+full_fan_speed_layer = 0
+max_fan_speed = 100
+min_fan_speed = 90
+min_print_speed = 10
+slowdown_below_layer_time = 15
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S0 ; Set and wait - chamber temperature"
+temperature = 210
+
+[filament:AzteQ Industrial (Door Opened) - PLA - Generic @0.6 nozzle]
+inherits = AzteQ Industrial (Door Opened) - PLA - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial (Door Opened) - PLA - ExtraFill (Fillamentum)]
+inherits = AzteQ Industrial (Door Opened) - PLA - Generic
+filament_vendor = Fillamentum
+filament_cost = 24.27
+filament_density = 1.24
+filament_spool_weight = 229
+
+[filament:AzteQ Industrial (Door Opened) - PLA - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial (Door Opened) - PLA - ExtraFill (Fillamentum) 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial (PLA Printhead) - PLA - ExtraFill (Fillamentum)]
+inherits = *AzteQ common* 
+bed_temperature = 50
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_cost = 24.27
+filament_density = 1.24
+filament_spool_weight = 229
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 6
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_toolchange_delay = 0
+filament_type = PLA
+filament_vendor = Fillamentum
+filament_wipe = 1
+first_layer_bed_temperature = 50
+first_layer_temperature = 220
+full_fan_speed_layer = 0
+max_fan_speed = 100
+min_fan_speed = 100
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S0 ; Set and wait - chamber temperature"
+temperature = 215
+
+[filament:AzteQ Industrial (PLA Printhead) - PLA - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial (PLA Printhead) - PLA - ExtraFill (Fillamentum) 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ABS - Generic]
+inherits = *AzteQ common* 
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.04
+filament_deretract_speed = nil
+filament_load_time = 0
+filament_loading_speed = 28
+filament_loading_speed_start = 3
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_spool_weight = 0
+filament_type = ABS
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+full_fan_speed_layer = 0
+max_fan_speed = 100
+min_fan_speed = 80
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+temperature = 255
+
+[filament:AzteQ Industrial - ABS - Generic @0.6 nozzle]
+inherits = AzteQ Industrial - ABS - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ABS - Generic @0.8 nozzle]
+inherits = AzteQ Industrial - ABS - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+first_layer_temperature = 255
+first_layer_bed_temperature = 100
+temperature = 255
+bed_temperature = 100
+max_fan_speed = 80
+min_fan_speed = 50
+filament_retract_length = 6.1
+filament_max_volumetric_speed = 0
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+
+[filament:AzteQ Industrial - ABS - ExtraFill (Fillamentum)]
+inherits = AzteQ Industrial - ABS - Generic 
+filament_vendor = Fillamentum
+filament_cost = 24.27
+filament_density = 1.04
+filament_spool_weight = 229
+
+[filament:AzteQ Industrial - ABS - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial - ABS - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+
+[filament:AzteQ Industrial - ABS - ExtraFill (Fillamentum) @0.8 nozzle]
+inherits = AzteQ Industrial - ABS - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+extrusion_multiplier = 0.95
+
+[filament:AzteQ Industrial - PC/ABS - (Fillamentum)]
+inherits = AzteQ Industrial - ABS - Generic 
+filament_vendor = Fillamentum
+filament_type = PCABS
+filament_cost = 53.71
+filament_spool_weight = 229
+filament_density = 1.07
+bed_temperature = 100
+filament_retract_length = 4.0
+first_layer_bed_temperature = 100
+first_layer_temperature = 265
+max_fan_speed = 50
+min_fan_speed = 50
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+temperature = 265
+filament_notes = "S180 ; Probing temperature"
+
+[filament:AzteQ Industrial - PC/ABS - (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial - PC/ABS - (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - PC - PolyMax (Polymaker)]
+inherits = AzteQ Industrial - ABS - Generic 
+filament_vendor = Polymaker
+filament_spool_weight = 230
+filament_cost = 52.40
+filament_density = 1.21
+bed_temperature = 100
+filament_retract_length = 4.0
+first_layer_bed_temperature = 100
+first_layer_temperature = 265
+max_fan_speed = 50
+min_fan_speed = 50
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+temperature = 265
+filament_notes = "S180 ; Probing temperature"
+
+[filament:AzteQ Industrial - PC - PolyMax (Polymaker) @0.6 nozzle]
+inherits = AzteQ Industrial - PC - PolyMax (Polymaker)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ASA - Generic]
+inherits = *AzteQ common* 
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_density = 1.07
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_spool_weight = 0
+filament_type = ASA
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 265
+full_fan_speed_layer = 0
+max_fan_speed = 75
+min_fan_speed = 50
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S50 ; Set and wait - chamber temperature"
+temperature = 265
+
+[filament:AzteQ Industrial - ASA - Generic @0.6 nozzle]
+inherits = AzteQ Industrial - ASA - Generic
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ASA - ExtraFill (Fillamentum)]
+inherits = AzteQ Industrial - ASA - Generic
+filament_vendor = Fillamentum
+first_layer_temperature = 255
+temperature = 255
+max_fan_speed = 80
+min_fan_speed = 60
+filament_spool_weight = 229
+filament_cost = 29.53
+filament_density = 1.07
+
+[filament:AzteQ Industrial - ASA - ExtraFill (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial - ASA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ASA - ExtraFill (Fillamentum) @0.8 nozzle]
+inherits = AzteQ Industrial - ASA - ExtraFill (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+first_layer_bed_temperature = 100
+bed_temperature = 100
+first_layer_temperature = 250
+temperature = 250
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S50 ; Set and wait - chamber temperature"
+max_fan_speed = 100
+min_fan_speed = 80
+filament_retract_length = 6.1
+filament_max_volumetric_speed = 0
+
+
+[filament:AzteQ Industrial - ASA - Prusament (Prusa)]
+inherits = AzteQ Industrial - ASA - Generic
+filament_cost = 29.16
+filament_density = 1.07
+filament_spool_weight = 201
+filament_vendor = Prusa
+first_layer_temperature = 260
+max_fan_speed = 70
+min_fan_speed = 70
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S50 ; Set and wait - chamber temperature"
+temperature = 260
+
+[filament:AzteQ Industrial - ASA - Prusament (Prusa) @0.6 nozzle]
+inherits = AzteQ Industrial - ASA - Prusament (Prusa)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - ASA - Prusament (Prusa) @0.8 nozzle]
+inherits = AzteQ Industrial - ASA - Prusament (Prusa)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+first_layer_bed_temperature = 100
+bed_temperature = 100
+first_layer_temperature = 250
+temperature = 250
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+max_fan_speed = 80
+min_fan_speed = 50
+filament_retract_length = 4.1
+filament_max_volumetric_speed = 0
+
+
+[filament:AzteQ Industrial - PA - Nylon PA12 (Fiberlogy)]
+inherits = *AzteQ common* 
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_cost = 45.11
+filament_spool_weight = 230
+filament_density = 1.02
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_toolchange_delay = 0
+filament_type = NYLON
+filament_unload_time = 0
+filament_unloading_speed = 90
+filament_unloading_speed_start = 100
+filament_vendor = Fiberlogy
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+full_fan_speed_layer = 0
+max_fan_speed = 75
+min_fan_speed = 50
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S50 ; Set and wait - chamber temperature"
+temperature = 255
+
+[filament:AzteQ Industrial - PA - Nylon PA12 (Fiberlogy) @0.6 nozzle]
+inherits = AzteQ Industrial - PA - Nylon PA12 (Fiberlogy)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - PA - Nylon FX256 (Fillamentum)]
+inherits = *AzteQ common* 
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_cost = 57.32
+filament_spool_weight = 229
+filament_density = 1.01
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 6.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_toolchange_delay = 0
+filament_type = NYLON
+filament_unload_time = 0
+filament_unloading_speed = 90
+filament_unloading_speed_start = 100
+filament_vendor = Fillamentum
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+full_fan_speed_layer = 0
+max_fan_speed = 85
+min_fan_speed = 50
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S60 ; Set and wait - chamber temperature"
+temperature = 255
+
+[filament:AzteQ Industrial - PA - Nylon FX256 (Fillamentum) @0.6 nozzle]
+inherits = AzteQ Industrial - PA - Nylon FX256 (Fillamentum)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - PC Blend - Prusament (Prusa)]
+inherits = *AzteQ common* 
+bed_temperature = 100
+bridge_fan_speed = 75
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_cost = 61.98
+filament_density = 1.22
+filament_spool_weight = 201
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 8
+filament_retract_before_travel = 3
+filament_retract_before_wipe = 70%
+filament_retract_layer_change = 1
+filament_retract_length = 4.1
+filament_retract_lift = 0.2
+filament_retract_lift_above = nil
+filament_retract_lift_below = nil
+filament_retract_restart_extra = nil
+filament_retract_speed = 25
+filament_soluble = 0
+filament_type = PC
+filament_vendor = Prusa
+filament_wipe = 1
+first_layer_bed_temperature = 100
+first_layer_temperature = 270
+full_fan_speed_layer = 0
+max_fan_speed = 50
+min_fan_speed = 30
+min_print_speed = 10
+slowdown_below_layer_time = 5
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+temperature = 270
+filament_notes = "S180 ; Probing temperature"
+
+[filament:AzteQ Industrial - PC Blend - Prusament (Prusa) @0.6 nozzle]
+inherits = AzteQ Industrial - PC Blend - Prusament (Prusa)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.6
+filament_max_volumetric_speed = 15
+
+[filament:AzteQ Industrial - PC Blend - Prusament (Prusa) @0.8 nozzle]
+inherits = AzteQ Industrial - PC Blend - Prusament (Prusa)
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes=~/.*PRINTER_MODEL_AQI.*/ and nozzle_diameter[0]==0.8
+first_layer_bed_temperature = 100
+bed_temperature = 100
+first_layer_temperature = 275
+temperature = 275
+start_filament_gcode = "; FILAMENT_START_GCODE\nM191 S75 ; Set and wait - chamber temperature"
+max_fan_speed = 60
+min_fan_speed = 60
+filament_retract_length = 7.1
+filament_max_volumetric_speed = 0
+
+           
+# DeltiQ Printer #
+
+[printer:*DeltiQ*]
+inherits = 
+bed_shape = 124.315x13.0661,122.268x25.989,118.882x38.6271,114.193x50.8421,108.253x62.5,101.127x73.4732,92.8931x83.6413,83.6413x92.8931,73.4732x101.127,62.5x108.253,50.8421x114.193,38.6271x118.882,25.989x122.268,13.0661x124.315,3.54096e-014x125,-13.0661x124.315,-25.989x122.268,-38.6271x118.882,-50.8421x114.193,-62.5x108.253,-73.4732x101.127,-83.6413x92.8931,-92.8931x83.6413,-101.127x73.4732,-108.253x62.5,-114.193x50.8421,-118.882x38.6271,-122.268x25.989,-124.315x13.0661,-125x7.08192e-014,-124.315x-13.0661,-122.268x-25.989,-118.882x-38.6271,-114.193x-50.8421,-108.253x-62.5,-101.127x-73.4732,-92.8931x-83.6413,-83.6413x-92.8931,-73.4732x-101.127,-62.5x-108.253,-50.8421x-114.193,-38.6271x-118.882,-25.989x-122.268,-13.0661x-124.315,-2.29621e-014x-125,13.0661x-124.315,25.989x-122.268,38.6271x-118.882,50.8421x-114.193,62.5x-108.253,73.4732x-101.127,83.6413x-92.8931,92.8931x-83.6413,101.127x-73.4732,108.253x-62.5,114.193x-50.8421,118.882x-38.6271,122.268x-25.989,124.315x-13.0661,125x-1.41638e-013
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\nG92 E0\n;[layer_z]
+between_objects_gcode = 
+cooling_tube_length = 5
+cooling_tube_retraction = 91.5
+default_filament_profile = "DeltiQ PLA"
+default_print_profile = DeltiQ 0.20mm Normal
+deretract_speed = 0
+end_gcode = ;END\nM104 S0 ; Turn extruder heater off\nM140 S0 ; Turn bed heater off\nG28 ; Home all axes\nM84 S5 ; Stop all axes and hold inidle for 5 seconds\nG90 ; Absolute positioning
+extra_loading_move = -2
+extruder_colour = #FF0000
+extruder_offset = 0x0
+gcode_flavor = repetier
+layer_gcode = ;AFTER_LAYER_CHANGE\nM117 layer [layer_num] at [layer_z]mm\n;[layer_z]\n
+max_layer_height = 0.25
+max_print_height = 300
+min_layer_height = 0.15
+nozzle_diameter = 0.4
+parking_pos_retraction = 92
+printer_model = 
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_TRILAB\nPRINTER_FAMILY_DQ\nPRINTER_MODEL_DQL
+printer_settings_id = 
+printer_variant = 
+printer_vendor = TriLAB Group s.r.o.
+remaining_times = 0
+retract_before_travel = 3
+retract_before_wipe = 100%
+retract_layer_change = 1
+retract_length = 4.0
+retract_length_toolchange = 10
+retract_lift = 0.2
+retract_lift_above = 0
+retract_lift_below = 0
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 30
+silent_mode = 0
+single_extruder_multi_material = 0
+start_gcode = ;START\nM220 S100 ; Set feedmultiply back to 100percent\nG90 ; Absolute positioning\nM83 ; Relative extruder\nM107 ; Layer fan OFF\nM190 S[first_layer_bed_temperature] ; Set bed temperature and wait\nM104 S[first_layer_temperature] ; Set extruder temperature\nG28 ; Home all axes\nG33 ; auto leveling rutine\nG1 X-62 Y-108 Z0.3 F6000 ; Go to purge position start\nG92 E0 ; Zero extruder\nM109 S[first_layer_temperature] ; Set and wait - hotend temperature\nG3 X62 Y-108 I62 J108 E10 F200 ; Go ARC to purge end\nG92 E0 ; Zero extruder
+thumbnails = 
+toolchange_gcode = 
+use_firmware_retraction = 0
+use_relative_e_distances = 1
+use_volumetric_e = 0
+variable_layer_height = 0
+wipe = 1
+z_offset = 0
+
+[printer:DeltiQ L]
+inherits = *DeltiQ*
+printer_model = DQL
+printer_variant = 0.4
+bed_shape = 124.315x13.0661,122.268x25.989,118.882x38.6271,114.193x50.8421,108.253x62.5,101.127x73.4732,92.8931x83.6413,83.6413x92.8931,73.4732x101.127,62.5x108.253,50.8421x114.193,38.6271x118.882,25.989x122.268,13.0661x124.315,3.54096e-014x125,-13.0661x124.315,-25.989x122.268,-38.6271x118.882,-50.8421x114.193,-62.5x108.253,-73.4732x101.127,-83.6413x92.8931,-92.8931x83.6413,-101.127x73.4732,-108.253x62.5,-114.193x50.8421,-118.882x38.6271,-122.268x25.989,-124.315x13.0661,-125x7.08192e-014,-124.315x-13.0661,-122.268x-25.989,-118.882x-38.6271,-114.193x-50.8421,-108.253x-62.5,-101.127x-73.4732,-92.8931x-83.6413,-83.6413x-92.8931,-73.4732x-101.127,-62.5x-108.253,-50.8421x-114.193,-38.6271x-118.882,-25.989x-122.268,-13.0661x-124.315,-2.29621e-014x-125,13.0661x-124.315,25.989x-122.268,38.6271x-118.882,50.8421x-114.193,62.5x-108.253,73.4732x-101.127,83.6413x-92.8931,92.8931x-83.6413,101.127x-73.4732,108.253x-62.5,114.193x-50.8421,118.882x-38.6271,122.268x-25.989,124.315x-13.0661,125x-1.41638e-013
+max_print_height = 300
+
+[printer:DeltiQ M]
+inherits = *DeltiQ*
+printer_variant = 0.4
+bed_shape = 89.507x9.40756,88.0333x18.7121,85.5951x27.8115,82.2191x36.6063,77.9423x45,72.8115x52.9007,66.883x60.2218,60.2218x66.883,52.9007x72.8115,45x77.9423,36.6063x82.2191,27.8115x85.5951,18.7121x88.0333,9.40756x89.507,2.54949e-014x90,-9.40756x89.507,-18.7121x88.0333,-27.8115x85.5951,-36.6063x82.2191,-45x77.9423,-52.9007x72.8115,-60.2218x66.883,-66.883x60.2218,-72.8115x52.9007,-77.9423x45,-82.2191x36.6063,-85.5951x27.8115,-88.0333x18.7121,-89.507x9.40756,-90x5.09899e-014,-89.507x-9.40756,-88.0333x-18.7121,-85.5951x-27.8115,-82.2191x-36.6063,-77.9423x-45,-72.8115x-52.9007,-66.883x-60.2218,-60.2218x-66.883,-52.9007x-72.8115,-45x-77.9423,-36.6063x-82.2191,-27.8115x-85.5951,-18.7121x-88.0333,-9.40756x-89.507,-1.65327e-014x-90,9.40756x-89.507,18.7121x-88.0333,27.8115x-85.5951,36.6063x-82.2191,45x-77.9423,52.9007x-72.8115,60.2218x-66.883,66.883x-60.2218,72.8115x-52.9007,77.9423x-45,82.2191x-36.6063,85.5951x-27.8115,88.0333x-18.7121,89.507x-9.40756,90x-1.0198e-013
+max_print_height = 230
+printer_model = DQM
+retract_length = 3.7
+retract_length_toolchange = 10
+retract_speed = 30
+start_gcode = ;START\nM220 S100 ; Set feedmultiply back to 100percent\nG90 ; Absolute positioning\nM83 ; Relative extruder\nM107 ; Layer fan OFF\nM190 S[first_layer_bed_temperature] ; Set bed temperature and wait\nM104 S[first_layer_temperature] ; Set extruder temperature\nG28 ; Home all axes\nG33 ; auto leveling rutine\nG1 X-45 Y-77 Z0.3 F6000 ; Go to purge position start\nG92 E0 ; Zero extruder\nM109 S[first_layer_temperature] ; Set Extruder Temperature and Wait\nG3 X45 Y-77 I45 J77 E10 F200 ; Go ARC to purge end\nG92 E0 ; Zero extruder
+
+[printer:DeltiQ XL]
+inherits = *DeltiQ*
+printer_model = DQXL
+printer_variant = 0.4
+bed_shape = 124.315x13.0661,122.268x25.989,118.882x38.6271,114.193x50.8421,108.253x62.5,101.127x73.4732,92.8931x83.6413,83.6413x92.8931,73.4732x101.127,62.5x108.253,50.8421x114.193,38.6271x118.882,25.989x122.268,13.0661x124.315,3.54096e-014x125,-13.0661x124.315,-25.989x122.268,-38.6271x118.882,-50.8421x114.193,-62.5x108.253,-73.4732x101.127,-83.6413x92.8931,-92.8931x83.6413,-101.127x73.4732,-108.253x62.5,-114.193x50.8421,-118.882x38.6271,-122.268x25.989,-124.315x13.0661,-125x7.08192e-014,-124.315x-13.0661,-122.268x-25.989,-118.882x-38.6271,-114.193x-50.8421,-108.253x-62.5,-101.127x-73.4732,-92.8931x-83.6413,-83.6413x-92.8931,-73.4732x-101.127,-62.5x-108.253,-50.8421x-114.193,-38.6271x-118.882,-25.989x-122.268,-13.0661x-124.315,-2.29621e-014x-125,13.0661x-124.315,25.989x-122.268,38.6271x-118.882,50.8421x-114.193,62.5x-108.253,73.4732x-101.127,83.6413x-92.8931,92.8931x-83.6413,101.127x-73.4732,108.253x-62.5,114.193x-50.8421,118.882x-38.6271,122.268x-25.989,124.315x-13.0661,125x-1.41638e-013
+max_print_height = 500
+retract_length = 4.5
+retract_speed = 35
+
+[printer:*DeltiQ 2*]
+inherits = *DeltiQ*
+before_layer_gcode = ; BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0\n
+end_gcode = ; END_GCODE\n\nM140 S0 ; Turn off bed\n\nG28 ; Home\n\nM104 S0 ; Turn off extruder\nM107 ; Turn off fan\n\nG90 ; Absolute positioning\nM220 S100  ; Feedmultiply back to 100percent\n\nM84 S5; Disable motors
+gcode_flavor = reprapfirmware
+layer_gcode = ; AFTER_LAYER_CHANGE\n;[layer_z]
+pause_print_gcode = M0
+start_gcode = ; START_GCODE\n\nM220 S100 ; Set feedmultiply back to 100percent\n\nT0 ; Select Titan extruder\n\nG90 ; Absolute positioning\nM83; Relative Extruder\n\nM190 S[first_layer_bed_temperature] ; Set and wait - bed temperature\nM104 S[first_layer_temperature]\n\nG28 ; Home all axes\nG32 ; Probe Z and calculate Z plane\n\nG29 ; Mesh bed probe\n\nG1009 ; Go ARC to purge end\n\nG92 E0 ; Zero extruder
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_TRILAB\nPRINTER_FAMILY_DQ\nPRINTER_MODEL_DQ2
+
+[printer:DeltiQ 2]
+inherits = *DeltiQ 2*
+printer_model = DQ2
+printer_variant = 0.4
+max_print_height = 300
+
+[printer:DeltiQ 2 - 0.25 nozzle]
+inherits = DeltiQ 2
+printer_variant = 0.25
+max_layer_height = 0.15
+min_layer_height = 0.07
+nozzle_diameter = 0.25
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.25 nozzle"
+default_print_profile = DeltiQ 0.07mm Quality @0.25 nozzle
+
+[printer:DeltiQ 2 - 0.6 nozzle]
+inherits = DeltiQ 2
+printer_variant = 0.6
+max_layer_height = 0.4
+min_layer_height = 0.2
+nozzle_diameter = 0.6
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.6 nozzle"
+default_print_profile = DeltiQ 0.30mm Normal @0.6 nozzle
+
+[printer:DeltiQ 2 - 0.8 nozzle]
+inherits = DeltiQ 2
+printer_variant = 0.8
+max_layer_height = 0.6
+min_layer_height = 0.3
+nozzle_diameter = 0.8
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.8 nozzle"
+default_print_profile = DeltiQ 0.40mm Normal @0.8 nozzle
+
+[printer:DeltiQ 2 Plus]
+inherits = *DeltiQ 2*
+printer_model = DQ2P
+printer_variant = 0.4
+max_print_height = 500
+
+[printer:DeltiQ 2 Plus - 0.25 nozzle]
+inherits = DeltiQ 2 Plus
+printer_variant = 0.25
+max_layer_height = 0.15
+min_layer_height = 0.07
+nozzle_diameter = 0.25
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.25 nozzle"
+default_print_profile = DeltiQ 0.07mm Quality @0.25 nozzle
+
+[printer:DeltiQ 2 Plus - 0.6 nozzle]
+inherits = DeltiQ 2 Plus
+printer_variant = 0.6
+max_layer_height = 0.4
+min_layer_height = 0.2
+nozzle_diameter = 0.6
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.6 nozzle"
+default_print_profile = DeltiQ 0.30mm Normal @0.6 nozzle
+
+[printer:DeltiQ 2 Plus - 0.8 nozzle]
+inherits = DeltiQ 2 Plus
+printer_variant = 0.8
+max_layer_height = 0.6
+min_layer_height = 0.3
+nozzle_diameter = 0.8
+default_filament_profile = "DeltiQ - PLA - ExtraFill (Fillamentum) @0.8 nozzle"
+default_print_profile = DeltiQ 0.40mm Normal @0.8 nozzle
+
+[printer:*DeltiQ 2 FlexPrint*]
+inherits = *DeltiQ 2*
+start_gcode = ; START_GCODE\n\nM220 S100 ; Set feedmultiply back to 100percent\n\nT1 ; Select FlexPrint extruder\n\nG90 ; Absolute positioning\nM83; Relative Extruder\n\nM190 S[first_layer_bed_temperature] ; Set and wait - bed temperature\nM104 S[first_layer_temperature]\n\nG28 ; Home all axes\nG32 ; Probe Z and calculate Z plane\n\nG29 ; Mesh bed probe\n\nG1009 ; Go ARC to purge end\n\nG92 E0 ; Zero extruder
+default_print_profile = DeltiQ 0.20mm FLEX
+default_filament_profile = "DeltiQ FP2 - FLEX - Generic"
+retract_length = 0.7
+retract_speed = 25
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_TRILAB\nPRINTER_FAMILY_DQ\nPRINTER_MODEL_DQ2+FP\nFLEXPRINT1
+
+[printer:DeltiQ 2 + FlexPrint]
+inherits = *DeltiQ 2 FlexPrint*
+printer_model = DQ2+FP
+printer_variant = 0.4
+max_print_height = 300
+
+[printer:DeltiQ 2 Plus + FlexPrint]
+inherits = *DeltiQ 2 FlexPrint*
+printer_model = DQ2P+FP
+printer_variant = 0.4
+max_print_height = 500
+
+[printer:*DeltiQ 2 FlexPrint 2*]
+inherits = *DeltiQ 2 FlexPrint*
+default_filament_profile = "DeltiQ FP2 - FLEX - Generic"
+retract_length = 0.8
+retract_speed = 25
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_TRILAB\nPRINTER_FAMILY_DQ\nPRINTER_MODEL_DQ2+FP\nFLEXPRINT2
+
+[printer:DeltiQ 2 + FlexPrint 2]
+inherits = *DeltiQ 2 FlexPrint 2*
+printer_model = DQ2+FP2
+printer_variant = 0.4
+max_print_height = 300
+
+[printer:DeltiQ 2 Plus + FlexPrint 2]
+inherits = *DeltiQ 2 FlexPrint 2*
+printer_model = DQ2P+FP2
+printer_variant = 0.4
+max_print_height = 500
+
+[printer:*AzteQ*]
+inherits = *DeltiQ 2*
+max_print_height = 400
+bed_shape = 149.429x13.0734,147.721x26.0472,144.889x38.8229,140.954x51.303,135.946x63.3927,129.904x75,122.873x86.0365,114.907x96.4181,106.066x106.066,96.4181x114.907,86.0365x122.873,75x129.904,63.3927x135.946,51.303x140.954,38.8229x144.889,26.0472x147.721,13.0734x149.429,9.18485e-15x150,-13.0734x149.429,-26.0472x147.721,-38.8229x144.889,-51.303x140.954,-63.3927x135.946,-75x129.904,-86.0365x122.873,-96.4181x114.907,-106.066x106.066,-114.907x96.4181,-122.873x86.0365,-129.904x75,-135.946x63.3927,-140.954x51.303,-144.889x38.8229,-147.721x26.0472,-149.429x13.0734,-150x1.83697e-14,-149.429x-13.0734,-147.721x-26.0472,-144.889x-38.8229,-140.954x-51.303,-135.946x-63.3927,-129.904x-75,-122.873x-86.0365,-114.907x-96.4181,-106.066x-106.066,-96.4181x-114.907,-86.0365x-122.873,-75x-129.904,-63.3927x-135.946,-51.303x-140.954,-38.8229x-144.889,-26.0472x-147.721,-13.0734x-149.429,-2.75546e-14x-150,13.0734x-149.429,26.0472x-147.721,38.8229x-144.889,51.303x-140.954,63.3927x-135.946,75x-129.904,86.0365x-122.873,96.4181x-114.907,106.066x-106.066,114.907x-96.4181,122.873x-86.0365,129.904x-75,135.946x-63.3927,140.954x-51.303,144.889x-38.8229,147.721x-26.0472,149.429x-13.0734,150x-3.67394e-14
+before_layer_gcode = ; BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0\n
+end_gcode = ; END_GCODE\n\nM140 S0 ; Turn off bed heater\nM141 S0 ; Turn off chamber heater\nM104 S0 ; Turn off hotend heater\n\nG28 ; Home all axes\n\nM107 ; Turn off layer fan\n\nG90 ; Absolute positioning for motion\nM220 S100 ; Feedmultiply back to 100percent\n\nM84 S5 ; Disable motor hold
+layer_gcode = ; AFTER_LAYER_CHANGE\n;[layer_z]
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_TRILAB\nPRINTER_FAMILY_AQ\nPRINTER_MODEL_AQI
+retract_before_travel = 3
+retract_before_wipe = 100%
+retract_layer_change = 1
+retract_length = 4
+retract_length_toolchange = 10
+retract_lift = 0.2
+retract_lift_above = 0
+retract_lift_below = 0
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 30
+start_gcode = ; START_GCODE\nT0\nM220 S100 ; Set feedmultiply back to 100 percent\nG90 ; Absolute positioning for motion\nM83 ; Relative extruder\nM107 ; Layer fan off\n\nM140 S[first_layer_bed_temperature] ; Set and continue - bed temperature\nM104 S150 ; Set and continue - hotend probing temperature\n[start_filament_gcode]\nM190 S[first_layer_bed_temperature] ; Set and wait - bed temperature\nM109 [filament_notes] ; Set and wait for material specific hotend probing temperature\n\nG28 ; Home all axes\nG32 ; Probe Z and calculate Z plane\nG29 ; Mesh bed probe\n\nM104 S[first_layer_temperature] ; Set and continue - printing temperature\n\nG1009 ; Purge hotend\nG92 E0 ; Zero extruder
+wipe = 1
+
+[printer:AzteQ Industrial]
+inherits = *AzteQ*
+printer_model = AQI
+printer_variant = 0.4
+max_print_height = 400
+default_filament_profile = "AzteQ Industrial - ABS - ExtraFill (Fillamentum)"
+default_print_profile = AzteQ Industrial 0.30mm Normal
+
+[printer:AzteQ Industrial - 0.6 nozzle]
+inherits = AzteQ Industrial
+printer_variant = 0.6
+max_layer_height = 0.4
+min_layer_height = 0.2
+nozzle_diameter = 0.6
+default_filament_profile = "AzteQ Industrial - ABS - ExtraFill (Fillamentum) @0.6 nozzle"
+default_print_profile = AzteQ Industrial 0.30mm Normal @0.6 nozzle
+
+[printer:AzteQ Industrial - 0.8 nozzle]
+inherits = AzteQ Industrial
+printer_variant = 0.8
+max_layer_height = 0.6
+min_layer_height = 0.2
+nozzle_diameter = 0.8
+default_filament_profile = "AzteQ Industrial - ABS - ExtraFill (Fillamentum) @0.8 nozzle"
+default_print_profile = AzteQ Industrial 0.40mm Normal @0.8 nozzle
+
+[presets]
+print = DeltiQ 0.20mm Normal
+printer = DeltiQ 2
+filament = DeltiQ - PLA - Generic

--- a/live/TriLAB/index.idx
+++ b/live/TriLAB/index.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.4.1-rc1
+1.0.1 Fix missing AzteQ Industrial ABS material for 0.6, 0.8 nozzle, enabled elefant foot compensation
 1.0.0 Added AzteQ Industrial profiles for 0.8 nozzle, updated spool weight and filament cost, some minor setting improvements
 min_slic3r_version = 2.3.2-alpha0
 0.0.9 Added AzteQ Industrial materials PC/ABS (Fillamentum), PC-Max (Polymaker), Nylon FX256 (Fillamentum), Added DeltiQ 2 materials Nylon PA12 (Fiberlogy), Nylon CF15 Carbon (Fillamentum), PEBA 90A - FlexFill (Fillamentum), MoldLay (Wax-Alike), disabled retract only when crossing perimeters, some minor setting improvements


### PR DESCRIPTION
Ahoj,

rád bych požádal o začlenění aktualizace do vašeho repozitáře. Aktualizace opravuje chybějící materiál ABS pro AzteQ Industrial. Při této příležitosti došlo k opětovnému zapnutí kompenzace první vrstvy, která byla do nedávna (z důvodu chyby v kombinaci s límcem) vypnuta.


Předem děkuji, s pozdravem Matěj