### PR TITLE
Artillery: retract_length is too large for direct extruders

### DIFF
--- a/live/Artillery/0.0.6.ini
+++ b/live/Artillery/0.0.6.ini
@@ -1,0 +1,515 @@
+###############
+# AUTHOR: Szabolcs Hornyak / design85@gmail.com
+# https://szabolcs.eu/2020/12/29/prusaslicer-sw-x1-genius/
+###############
+
+## Artillery Hornet printer profile is based on PR https://github.com/slic3r/slic3r-profiles/pull/14 created by https://github.com/newbeetle
+
+# Print profiles for the Artillery printers.
+
+[vendor]
+# Vendor name will be shown by the Config Wizard.
+name = Artillery
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the PrusaSlicer configuration to be downgraded.
+config_version = 0.0.6
+# Where to get the updates from?
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Artillery/
+# changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
+
+# The printer models will be shown by the Configuration Wizard in this order,
+# also the first model installed & the first nozzle installed will be activated after install.
+# Printer model name will be shown by the installation wizard.
+
+#############
+## PRINTER ##
+#############
+
+[printer_model:X1]
+name = Artillery Sidewinder X1
+variants = 0.4
+technology = FFF
+bed_model = bed-x1.stl
+bed_texture = bed-x1.png
+default_materials = Generic PLA @Artillery; Generic ABS @Artillery; Generic PETG @Artillery; Generic TPU @Artillery
+
+[printer_model:Genius]
+name = Artillery Genius
+variants = 0.4
+technology = FFF
+bed_model = bed-genius.stl
+bed_texture = bed-genius.png
+default_materials = Generic PLA @Artillery; Generic ABS @Artillery; Generic PETG @Artillery; Generic TPU @Artillery
+
+[printer_model:Hornet]
+name = Artillery Hornet
+variants = 0.4
+technology = FFF
+bed_model = bed-hornet.stl
+bed_texture = bed-hornet.png
+default_materials = Generic PLA @Artillery; Generic ABS @Artillery; Generic PETG @Artillery; Generic TPU @Artillery
+
+# Common printer preset
+[printer:*common*]
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0
+between_objects_gcode = 
+cooling_tube_length = 5
+cooling_tube_retraction = 91.5
+default_filament_profile = Generic PLA @Artillery
+default_print_profile = 0.20mm NORMAL @Artillery
+deretract_speed = 0
+extruder_colour = #FFFF00
+extruder_offset = 0x0
+gcode_flavor = marlin
+layer_gcode = ;AFTER_LAYER_CHANGE\n;[layer_z]
+machine_limits_usage = emit_to_gcode
+machine_max_acceleration_e = 5000,5000
+machine_max_acceleration_extruding = 1250,1250
+machine_max_acceleration_retracting = 1250,1250
+machine_max_acceleration_x = 1000,960
+machine_max_acceleration_y = 1000,960
+machine_max_acceleration_z = 1000,1000
+machine_max_feedrate_e = 120,120
+machine_max_feedrate_x = 200,100
+machine_max_feedrate_y = 200,100
+machine_max_feedrate_z = 12,12
+machine_max_jerk_e = 1.5,1.5
+machine_max_jerk_x = 8,8
+machine_max_jerk_y = 8,8
+machine_max_jerk_z = 0.4,0.4
+machine_min_extruding_rate = 0,0
+machine_min_travel_rate = 0,0
+max_layer_height = 0.25
+max_print_height = 250
+min_layer_height = 0.07
+nozzle_diameter = 0.4
+pause_print_gcode = 
+printer_technology = FFF
+remaining_times = 0
+retract_before_travel = 1
+retract_before_wipe = 0%
+retract_layer_change = 1
+retract_length = 0.8
+retract_length_toolchange = 4
+retract_lift = 0.6
+retract_lift_above = 0
+retract_lift_below = 380
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 35
+silent_mode = 0
+single_extruder_multi_material = 0
+toolchange_gcode = 
+use_firmware_retraction = 0
+use_relative_e_distances = 1
+use_volumetric_e = 0
+variable_layer_height = 1
+wipe = 1
+z_offset = 0
+end_gcode = G4 ; wait\nG92 E0 ; prepare to retract\nG1 E-0.5 F3000; retract to avoid stringing\n\n; Anti-stringing end wiggle\nG91 ; use relative coordinates\nG1 X1 Y1 F1200\n\n; Raise nozzle and present bed\n{if layer_z < max_print_height}G1 Z{z_offset+min(layer_z+120, max_print_height)}{endif} ; Move print head up\nG90 ; use absolute coordinates\n\n; Reset print setting overrides\nM200 D0 ; disable volumetric e\nM220 S100 ; reset speed factor to 100%\nM221 S100 ; reset extrusion rate to 100%\n\n; Shut down printer\nM106 S0 ; turn-off fan\nM104 S0 ; turn-off hotend\nM140 S0 ; turn-off bed\nM150 P0 ; turn off led\nM85 S0 ; deactivate idle timeout\nM84 ; disable motors\n
+
+[printer:*common_STOCK_FW*]
+inherits = *common*
+start_gcode = ; Initial setups\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM220 S100 ; reset speed factor to 100%\nM221 S100 ; reset extrusion rate to 100%\n\n; Set the heating\nM190 S[first_layer_bed_temperature] ; wait for bed to heat up\nM104 S[first_layer_temperature] ; start nozzle heating but don't wait\n\n; Home\nG1 Z3 F3000 ; move z up little to prevent scratching of surface\nG28 ; home all axes\nG1 X3 Y3 F5000 ; move to corner of the bed to avoid ooze over centre\n\n; Wait for final heating\nM109 S[first_layer_temperature] ; wait for the nozzle to heat up\nM190 S[first_layer_bed_temperature] ; wait for the bed to heat up\n\n; Return to prime position, Prime line routine\nG92 E0 ; Reset Extruder\nG1 Z3 F3000 ; move z up little to prevent scratching of surface\nG1 X10 Y.5 Z0.25 F5000.0 ; Move to start position\nG1 X100 Y.5 Z0.25 F1500.0 E15 ; Draw the first line\nG1 X100 Y.2 Z0.25 F5000.0 ; Move to side a little\nG1 X10 Y.2 Z0.25 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nM221 S{if layer_height<0.075}100{else}95{endif}
+
+[printer:*common_UPD_FW*]
+inherits = *common*
+start_gcode = ; Initial setups\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM900 K0.12 ; K factor\nM900 W[extrusion_width] H[layer_height] D[filament_diameter]\nM200 D0 ; disable volumetric e\nM220 S100 ; reset speed factor to 100%\nM221 S100 ; reset extrusion rate to 100%\n\n; Set the heating\nM190 S[first_layer_bed_temperature] ; wait for bed to heat up\nM104 S[first_layer_temperature] ; start nozzle heating but don't wait\n\n; Home\nG1 Z3 F3000 ; move z up little to prevent scratching of surface\nG28 ; home all axes\nG1 X3 Y3 F5000 ; move to corner of the bed to avoid ooze over centre\n\n; Wait for final heating\nM109 S[first_layer_temperature] ; wait for the nozzle to heat up\nM190 S[first_layer_bed_temperature] ; wait for the bed to heat up\n\n;Auto bed Leveling\n@BEDLEVELVISUALIZER\nG29 ; ABL T\nM420 S1 Z3 ; reload and fade mesh bed leveling until it reach 3mm Z\n\n; Return to prime position, Prime line routine\nG92 E0 ; Reset Extruder\nG1 Z3 F3000 ; move z up little to prevent scratching of surface\nG1 X10 Y.5 Z0.25 F5000.0 ; Move to start position\nG1 X100 Y.5 Z0.25 F1500.0 E15 ; Draw the first line\nG1 X100 Y.2 Z0.25 F5000.0 ; Move to side a little\nG1 X10 Y.2 Z0.25 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nM221 S{if layer_height<0.075}100{else}95{endif}
+
+[printer:*bowden*]
+inherits = *common_STOCK_FW*
+retract_length = 5
+retract_lift = 0.1
+retract_before_wipe = 50%
+default_filament_profile = Generic PLA @Artillery
+
+[printer:*0.4nozzle*]
+nozzle_diameter = 0.4
+max_layer_height = 0.32
+min_layer_height = 0.04
+printer_variant = 0.4
+default_print_profile = 0.20mm NORMAL @Artillery
+
+[printer:Artillery Sidewinder X1]
+inherits = *common_STOCK_FW*
+renamed_from = "Sidewinder X1"
+printer_model = X1
+printer_variant = 0.4
+bed_shape = 0x0,300x0,300x300,0x300
+max_print_height = 400
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_Artillery\nPRINTER_MODEL_X1
+
+[printer:Artillery Sidewinder X1 BL-TOUCH]
+inherits = *common_UPD_FW*
+renamed_from = "Sidewinder X1 BL-TOUCH"
+printer_model = X1
+printer_variant = 0.4
+bed_shape = 0x0,300x0,300x300,0x300
+max_print_height = 400
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_Artillery\nPRINTER_MODEL_X1
+
+[printer:Artillery Genius]
+inherits = *common_STOCK_FW*
+renamed_from = "Genius"
+printer_model = Genius
+printer_variant = 0.4
+bed_shape = 0x0,220x0,220x220,0x220
+max_print_height = 250
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_Artillery\nPRINTER_MODEL_Genius
+
+[printer:Artillery Genius BL-TOUCH]
+inherits = *common_UPD_FW*
+renamed_from = "Genius BL-TOUCH"
+printer_model = Genius
+printer_variant = 0.4
+bed_shape = 0x0,220x0,220x220,0x220
+max_print_height = 250
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_Artillery\nPRINTER_MODEL_Genius
+
+[printer:Artillery Hornet]
+inherits = *bowden*
+printer_model = Hornet
+printer_variant = 0.4
+bed_shape = 0x0,220x0,220x220,0x220
+max_print_height = 250
+machine_limits_usage = time_estimate_only
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_Artillery\nPRINTER_MODEL_Hornet\nPRINTER_HAS_Bowden
+
+###########
+## PRINT ##
+###########
+# Common print preset
+[print:*common*]
+# V2.2 #
+#bottom_fill_pattern = rectilinear
+#top_fill_pattern = rectilinear
+#fill_pattern = cubic
+# V2.3 #
+top_fill_pattern = monotonic
+bottom_fill_pattern = monotonic
+fill_pattern = adaptivecubic
+
+avoid_crossing_perimeters = 0
+bridge_acceleration = 1000
+bridge_angle = 0
+bridge_flow_ratio = 0.78
+bridge_speed = 20
+# brim_width = 5
+bottom_solid_min_thickness = 1.2
+clip_multipart_objects = 1
+compatible_printers = 
+complete_objects = 0
+default_acceleration = 1000
+dont_support_bridges = 1
+elefant_foot_compensation = 0
+ensure_vertical_shell_thickness = 1
+external_perimeter_extrusion_width = 0.45
+external_perimeter_speed = 25
+external_perimeters_first = 0
+extra_perimeters = 0
+extruder_clearance_height = 25
+extruder_clearance_radius = 45
+extrusion_width = 0.45
+fill_angle = 45
+fill_density = 15%
+first_layer_acceleration = 500
+first_layer_extrusion_width = 0.42
+first_layer_height = 150%
+first_layer_speed = 20
+gap_fill_speed = 30
+gcode_comments = 1
+gcode_label_objects = 1
+infill_acceleration = 1000
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.45
+infill_first = 0
+infill_only_where_needed = 0
+infill_overlap = 25%
+infill_speed = 50
+interface_shells = 0
+max_print_speed = 150
+max_volumetric_extrusion_rate_slope_negative = 0
+max_volumetric_extrusion_rate_slope_positive = 0
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+overhangs = 1
+only_retract_when_crossing_perimeters = 0
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+perimeters = 3
+perimeter_acceleration = 800
+perimeter_extruder = 1
+perimeter_extrusion_width = 0
+perimeter_speed = 45
+post_process = 
+print_settings_id = 
+raft_layers = 0
+resolution = 0
+seam_position = nearest
+single_extruder_multi_material_priming = 0
+skirts = 1
+skirt_distance = 6
+skirt_height = 1
+small_perimeter_speed = 25
+solid_infill_below_area = 0
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.45
+solid_infill_speed = 50
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.35
+support_material_interface_extruder = 0
+support_material_angle = 0
+support_material_buildplate_only = 0
+support_material_enforce_layers = 0
+support_material_contact_distance = 0.15
+support_material_interface_contact_loops = 0
+support_material_interface_layers = 2
+support_material_interface_spacing = 0.2
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 50
+support_material_synchronize_layers = 0
+support_material_threshold = 55
+support_material_with_sheath = 0
+support_material_xy_spacing = 50%
+thin_walls = 1
+travel_speed = 130
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 30
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 170
+wipe_tower_y = 125
+xy_size_compensation = 0
+
+[print:*0.08mm*]
+inherits = *common*
+default_acceleration = 500
+layer_height = 0.08
+perimeters = 3
+bottom_solid_layers = 9
+top_solid_layers = 11
+
+[print:*0.10mm*]
+inherits = *common*
+default_acceleration = 500
+layer_height = 0.1
+perimeters = 3
+bottom_solid_layers = 7
+top_solid_layers = 9
+
+[print:*0.12mm*]
+inherits = *common*
+default_acceleration = 500
+layer_height = 0.12
+perimeters = 3
+bottom_solid_layers = 6
+top_solid_layers = 7
+
+[print:*0.16mm*]
+inherits = *common*
+layer_height = 0.16
+bottom_solid_layers = 5
+top_solid_layers = 7
+
+[print:*0.20mm*]
+inherits = *common*
+layer_height = 0.20
+bottom_solid_layers = 4
+top_solid_layers = 5
+
+[print:*0.24mm*]
+inherits = *common*
+layer_height = 0.24
+top_infill_extrusion_width = 0.45
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+[print:*0.28mm*]
+inherits = *common*
+layer_height = 0.28
+first_layer_height = 0.36
+top_infill_extrusion_width = 0.45
+first_layer_extrusion_width = 0.75
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+[print:0.08mm SUPERDETAIL @Artillery]
+inherits = *0.08mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.10mm HIGHDETAIL @Artillery]
+inherits = *0.10mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.12mm DETAIL @Artillery]
+inherits = *0.12mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.16mm OPTIMAL @Artillery]
+inherits = *0.16mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.20mm SLOW @Artillery]
+inherits = *0.20mm*
+external_perimeter_speed = 15
+fill_density = 20%
+gap_fill_speed = 25
+infill_speed = 50
+perimeter_speed = 30
+perimeters = 3
+solid_infill_speed = 50
+top_solid_infill_speed = 25
+first_layer_speed = 15
+travel_speed = 100
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.20mm NORMAL @Artillery]
+inherits = *0.20mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.20mm SPEED @Artillery]
+inherits = *0.20mm*
+external_perimeter_speed = 35
+fill_density = 15%
+fill_pattern = grid
+gap_fill_speed = 45
+infill_speed = 150
+infill_only_where_needed = 1
+perimeter_speed = 60
+perimeters = 2
+solid_infill_speed = 150
+top_solid_infill_speed = 50
+travel_speed = 170
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.24mm DRAFT @Artillery]
+inherits = *0.24mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+[print:0.28mm SUPERDRAFT @Artillery]
+inherits = *0.28mm*
+compatible_printers_condition = printer_model=~/(X1|Genius|Hornet).*/ and nozzle_diameter[0]==0.4
+
+###############
+## FILAMENTS ##
+###############
+
+# Common filament preset
+[filament:*common*]
+cooling = 1
+compatible_printers = 
+extrusion_multiplier = 1
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 15
+slowdown_below_layer_time = 15
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_Artillery.*/
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #428AF5
+filament_cost = 20
+filament_density = 1.24
+filament_max_volumetric_speed = 15
+filament_type = PLA
+first_layer_bed_temperature = 65
+first_layer_temperature = 210
+full_fan_speed_layer = 3
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 205
+
+[filament:*PET*]
+inherits = *common*
+bed_temperature = 70
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_colour = #42E9F5
+filament_cost = 30
+filament_density = 1.27
+filament_max_volumetric_speed = 8
+filament_type = PETG
+first_layer_bed_temperature = 70
+first_layer_temperature = 235
+max_fan_speed = 50
+min_fan_speed = 20
+temperature = 230
+
+[filament:*ABS*]
+inherits = *common*
+bed_temperature = 90
+bridge_fan_speed = 30
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #6603FC
+filament_cost = 20
+filament_density = 1.04
+filament_max_volumetric_speed = 11
+filament_type = ABS
+first_layer_bed_temperature = 90
+first_layer_temperature = 240
+max_fan_speed = 0
+min_fan_speed = 0
+temperature = 240
+top_fan_speed = 0
+
+[filament:*TPU*]
+inherits = *common*
+bed_temperature = 55
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #CFFFFB
+filament_cost = 30
+filament_density = 1.2
+filament_max_volumetric_speed = 11
+filament_retract_before_travel = 4
+filament_retract_length = 2.5
+filament_retract_speed = 30
+filament_type = TPU
+first_layer_bed_temperature = 55
+first_layer_temperature = 210
+max_fan_speed = 70
+min_fan_speed = 0
+
+[filament:Generic PLA @Artillery]
+inherits = *PLA*
+filament_vendor = Generic
+
+[filament:Generic PETG @Artillery]
+inherits = *PET*
+filament_vendor = Generic
+
+[filament:Generic ABS @Artillery]
+inherits = *ABS*
+filament_vendor = Generic
+
+[filament:Generic TPU @Artillery]
+inherits = *TPU*
+filament_vendor = Generic

--- a/live/Artillery/index.idx
+++ b/live/Artillery/index.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.4.1-alpha0
+0.0.6 Reduced retract_length for direct extruders
 0.0.5 Added Artillery Hornet
 min_slic3r_version = 2.3.1-beta
 0.0.4 Fixed first layer height in 0.28mm profile.


### PR DESCRIPTION
Changed `retract_length` from default 1.9mm to 0.8mm.

Reason behind this change is that many people who use defaults encounter issues due to retraction distance set for value that large.

If you look at [diagram](https://wiki.e3d-online.com/File:KR1-BREAK-Rev5-1.png) of kraken heatbreak (which is drop-in replacement for stock heatbreak), you'll see that throat length is 2.95mm long.
Considering that direct extruders don't have a slack to compensate for, every retraction pulls partially molten filament into supposedly cold area basically halfway up the throat.

It is not very noticeable for people with default PTFE-lined extruder because plastic don't stick to PTFE (although sometimes it causes issue with materials printed at lower temps, but basically all people who install all-metal heatbreak start complaining about print quality.

Many members of community settled at around 0.6mm retractions as it seems but it might not be quite enough because people often don't dry their filament so that's why 0.8mm was chosen.

I was considering moving retraction settings to filament settings as it is how it's done in prusa profiles but decided against that simply because it might just remove retractions for people who use default printer profile.