### PR TITLE
Update MakerGear Profiles v0.1.1

### DIFF
--- a/live/MakerGear/0.1.1.ini
+++ b/live/MakerGear/0.1.1.ini
@@ -1,0 +1,1754 @@
+# Print profiles for the MakerGear printers.
+
+[vendor]
+name = MakerGear
+config_version = 0.1.0
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/MakerGear/
+
+[printer_model:MAKERGEAR_MICRO]
+# bed_model = waiting on this one
+default_materials = MakerGear PLA @MakerGear_MICRO
+family = MakerGear Micro
+name = Micro
+technology = FFF
+variants = 0.40
+
+[printer_model:MAKERGEAR_M2]
+bed_model = M2_M3.stl
+bed_texture = M2_M3.svg
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear M2
+name = MakerGear M2(V4 Hotend)
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M2_DUAL]
+bed_model = M2_M3.stl
+bed_texture = M2_M3.svg
+default_materials = MakerGear PLA @MakerGear; Empty @MakerGear
+family = MakerGear M2
+name = MakerGear M2 Dual
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M3_SE]
+bed_model = M2_M3.stl
+bed_texture = M2_M3.svg
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear M3-SE
+name = M3 - Single Extruder
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M3_ID_0]
+bed_model = M2_M3.stl
+bed_texture = M2_M3.svg
+thumbnail = MAKERGEAR_M3_thumbnail.png
+default_materials = MakerGear PLA @MakerGear; Empty @MakerGear
+family = MakerGear M3-ID Rev.0
+name = M3 - Independent Dual Rev.0
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M3_ID_0_DUPLICATION]
+thumbnail = MAKERGEAR_M3_DUPLICATION_thumbnail.png
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear M3-ID Rev.0
+name = M3 - Independent Dual Rev.0 (Duplication Mode)
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M3_ID_1]
+bed_model = M2_M3.stl
+bed_texture = M2_M3.svg
+thumbnail = MAKERGEAR_M3_thumbnail.png
+default_materials = MakerGear PLA @MakerGear; Empty @MakerGear
+family = MakerGear M3-ID Rev.1
+name = M3 - Independent Dual Rev.1
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_M3_ID_1_DUPLICATION]
+thumbnail = MAKERGEAR_M3_DUPLICATION_thumbnail.png
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear M3-ID Rev.1
+name = M3 - Independent Dual Rev.1 (Duplication Mode)
+technology = FFF
+variants = 0.35; 0.50; 0.25; 0.75
+
+[printer_model:MAKERGEAR_U1]
+# bed_model = 
+# bed_texture = 
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear Ultra One
+name = Ultra One
+technology = FFF
+variants = 0.50; 0.25; 0.35; 0.75
+
+[printer_model:MAKERGEAR_U1_DUPLICATION]
+# bed_model = 
+# bed_texture = 
+thumbnail = MAKERGEAR_U1_thumbnail.png
+default_materials = MakerGear PLA @MakerGear
+family = MakerGear Ultra One
+name = Ultra One (Duplication Mode)
+technology = FFF
+variants = 0.50; 0.25; 0.35; 0.75
+
+# ---------------------------
+# All presets starting with asterisk, for example *common*, are intermediate and they will
+# not make it into the user interface.
+
+# /~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\
+# |~~~ Common Print Settings ~~~|
+# \~~~~~~~~~~~~~~~~~~~~~~~~~~~~~/
+
+#0.35mm Nozzle
+[print:*common*]
+avoid_crossing_perimeters = 0
+bottom_fill_pattern = rectilinear
+bridge_angle = 0
+bridge_flow_ratio = 0.95
+bridge_speed = 65
+brim_width = 0
+brim_type = outer_only
+clip_multipart_objects = 1
+complete_objects = 0
+dont_support_bridges = 0
+elefant_foot_compensation = 0.1
+ensure_vertical_shell_thickness = 1
+external_fill_pattern = rectilinear
+external_perimeter_extrusion_width = 0.42
+external_perimeter_speed = 80
+external_perimeters_first = 1
+extra_perimeters = 1
+extruder_clearance_height = 25
+extruder_clearance_radius = 45
+extrusion_width = 0.42
+fill_angle = 45
+fill_density = 15%
+fill_pattern = gyroid
+first_layer_extrusion_width = 0.42
+first_layer_height = 0.16
+first_layer_speed = 35
+gap_fill_speed = 30
+gcode_comments = 0
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.42
+infill_first = 0
+infill_only_where_needed = 0
+infill_overlap = 20%
+infill_speed = 90
+interface_shells = 0
+max_print_speed = 100
+max_volumetric_extrusion_rate_slope_negative = 0
+max_volumetric_extrusion_rate_slope_positive = 0
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+only_retract_when_crossing_perimeters = 1
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+overhangs = 1
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.42
+perimeter_generator = arachne
+perimeter_speed = 65
+perimeters = 2
+raft_first_layer_density = 60
+raft_layers = 0
+resolution = 0
+seam_position = aligned
+single_extruder_multi_material_priming = 0
+skirt_distance = 2
+skirt_height = 1
+skirts = 3
+small_perimeter_speed = 25
+solid_infill_below_area = 0
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.42
+solid_infill_speed = 30
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 1
+support_material_angle = 50
+support_material_buildplate_only = 0
+support_material_contact_distance = 0.25
+support_material_enforce_layers = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.42
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 0
+support_material_interface_layers = 2
+support_material_interface_spacing = 0.3
+support_material_interface_speed = 100%
+support_material_pattern = honeycomb
+support_material_spacing = 2
+support_material_speed = 60
+support_material_style = snug
+support_material_synchronize_layers = 0
+support_material_threshold = 65
+support_material_with_sheath = 0
+support_material_xy_spacing = 200%
+thin_walls = 1
+top_fill_pattern = rectilinear
+top_infill_extrusion_width = 0.42
+top_solid_infill_speed = 35
+travel_speed = 150
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 170
+wipe_tower_y = 40
+xy_size_compensation = 0
+
+# /~~~~~~~~~~~~~~~~~~~~~~~\
+# |~~~ Nozzle Variants ~~~|
+# \~~~~~~~~~~~~~~~~~~~~~~~/
+[print:*0.25nozzle*]
+elefant_foot_compensation = 0
+external_perimeter_extrusion_width = 0.30
+extrusion_width = 0.30
+first_layer_extrusion_width = 0.3
+infill_extrusion_width = 0.30
+output_filename_format = {input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+perimeter_extrusion_width = 0.30
+solid_infill_extrusion_width = 0.30
+support_material_extrusion_width = 0.30
+support_material_interface_layers = 0
+support_material_interface_spacing = 0.15
+support_material_spacing = 1
+support_material_xy_spacing = 150%
+top_infill_extrusion_width = 0.30
+
+ ; Only for the MakerGear Micro 
+[print:*0.40nozzle*]
+bottom_solid_min_thickness = 0.5
+bridge_speed = 55
+external_perimeter_extrusion_width = 0.45
+external_perimeter_speed = 35
+extrusion_width = 0.45
+first_layer_extrusion_width = 0.42
+infill_anchor_max = 15
+infill_extrusion_width = 0.45
+infill_speed = 40
+output_filename_format = {input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+overhangs = 1 
+perimeter_extrusion_width = 0.45
+perimeter_speed = 35
+small_perimeter_speed = 35
+solid_infill_extrusion_width = 0.45
+solid_infill_speed = 45
+support_material = 1
+support_material_auto = 1
+support_material_contact_distance = 0.3
+support_material_extrusion_width = 0.45
+support_material_interface_layers = 1
+support_material_interface_spacing = 0.3
+support_material_spacing = 2.5
+support_material_speed = 35
+support_material_threshold = 60
+support_material_with_sheath = 1
+support_material_xy_spacing = 80%
+top_infill_extrusion_width = 0.45
+top_solid_infill_speed = 25
+top_solid_min_thickness = 0.7
+
+[print:*0.50nozzle*]
+bottom_solid_min_thickness = 0.5
+external_perimeter_extrusion_width = 0.60
+extrusion_width = 0.60
+first_layer_extrusion_width = 0.60
+infill_anchor_max = 15
+infill_extrusion_width = 0.60
+output_filename_format = {input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+perimeter_extrusion_width = 0.60
+solid_infill_extrusion_width = 0.60
+support_material_contact_distance = 0.25
+support_material_extrusion_width = 0.60
+support_material_interface_spacing = 0.3
+support_material_xy_spacing = 180%
+top_infill_extrusion_width = 0.60
+top_solid_min_thickness = 0.8
+
+[print:*0.75nozzle*]
+bottom_solid_layers = 2
+bottom_solid_min_thickness = 0.6
+bridge_acceleration = 1000
+bridge_flow_ratio = 0.9
+bridge_speed = 22
+default_acceleration = 1000
+external_perimeter_extrusion_width = 0.84
+extrusion_width = 0.84
+fill_density = 10%
+fill_pattern = gyroid
+first_layer_acceleration = 1000
+first_layer_extrusion_width = 0.94
+first_layer_height = 0.3
+first_layer_speed = 20
+gap_fill_speed = 20
+infill_acceleration = 1000
+infill_anchor_max = 20
+infill_extrusion_width = 0.84
+infill_speed = 85
+infill_overlap = 25%
+output_filename_format = {input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
+perimeter_acceleration = 800
+perimeter_extrusion_width = 0.84
+single_extruder_multi_material_priming = 0
+skirt_distance = 3
+skirt_height = 2
+solid_infill_speed = 55
+solid_infill_extrusion_width = 0.84
+support_material_contact_distance = 0.3
+support_material_extrusion_width = 0.7
+support_material_interface_spacing = 0.4
+support_material_interface_speed = 175%
+support_material_spacing = 2
+support_material_threshold = 50
+support_material_xy_spacing = 200%
+top_infill_extrusion_width = 0.8
+top_solid_layers = 4
+top_solid_min_thickness = 1.2
+
+# /~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\
+# |~~~ Layer Height Settings ~~~|
+# \~~~~~~~~~~~~~~~~~~~~~~~~~~~~~/
+# ---------------------------
+#      (not used) 0.05mm
+# ---------------------------
+[print:*0.05mm*]
+inherits = *common*
+bottom_solid_layers = 10
+bridge_acceleration = 300
+bridge_flow_ratio = 0.7
+default_acceleration = 1000
+external_perimeter_speed = 20
+fill_density = 15%
+first_layer_acceleration = 500
+gap_fill_speed = 20
+infill_acceleration = 800
+infill_speed = 30
+layer_height = 0.05
+max_print_speed = 80
+perimeter_acceleration = 300
+perimeter_speed = 30
+perimeters = 3
+small_perimeter_speed = 20
+solid_infill_speed = 30
+support_material_extrusion_width = 0.3
+support_material_spacing = 1.5
+support_material_speed = 30
+top_solid_infill_speed = 20
+top_solid_layers = 15
+
+# [print:NOT READY 0.05mm ULTRAFINE @0.25 nozzle] # M2, M3, U1
+# inherits = *0.05mm*; *0.25nozzle*
+# compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.25
+
+# ---------------------------
+# 0.07mm (Testing)
+# ---------------------------
+[print:*0.07mm*]
+inherits = *common*
+bottom_solid_layers = 8
+bridge_acceleration = 300
+bridge_flow_ratio = 0.7
+bridge_speed = 20
+default_acceleration = 1000
+external_perimeter_speed = 20
+fill_density = 15%
+first_layer_acceleration = 500
+gap_fill_speed = 20
+infill_acceleration = 800
+infill_speed = 40
+layer_height = 0.07
+max_print_speed = 80
+perimeter_acceleration = 300
+perimeter_speed = 30
+perimeters = 3
+small_perimeter_speed = 20
+solid_infill_speed = 40
+support_material_extrusion_width = 0.3
+support_material_spacing = 1.5
+support_material_speed = 40
+top_solid_infill_speed = 30
+top_solid_layers = 11
+
+# [print:NOT READY  0.07mm Quality @0.25 nozzle] # M2, M3, U1
+# inherits = *0.07mm*; *0.25nozzle*
+# compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.25
+
+# ---------------------------
+# 0.10mm (Testing)
+# ---------------------------
+[print:*0.10mm*]
+inherits = *common*
+bottom_solid_layers = 7
+bridge_flow_ratio = 0.7
+bridge_speed = 20
+fill_density = 15%
+first_layer_speed = 25
+gap_fill_speed = 20
+infill_speed = 40
+layer_height = 0.1
+max_print_speed = 80
+perimeter_acceleration = 800
+perimeter_speed = 30
+perimeters = 3
+small_perimeter_speed = 20
+solid_infill_speed = 40
+support_material_extrusion_width = 0.3
+support_material_spacing = 1.5
+support_material_speed = 40
+top_solid_infill_speed = 30
+top_solid_layers = 9
+
+ # M2, M3, U1
+[print:0.10mm Fine @0.35 nozzle MakerGear]
+inherits = *0.10mm*
+bridge_speed = 40
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.35
+external_perimeter_speed = 45
+fill_density = 15%
+fill_pattern = 3dhoneycomb
+infill_acceleration = 1000
+infill_speed = 55
+max_print_speed = 200
+perimeter_speed = 45
+solid_infill_speed = 80
+top_solid_infill_speed = 40
+
+# ---------------------------
+# 0.15mm
+# ---------------------------
+[print:*0.15mm*]
+inherits = *common*
+bottom_solid_layers = 5
+external_perimeter_speed = 40
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.15
+perimeter_acceleration = 800
+perimeter_speed = 50
+solid_infill_speed = 50
+top_infill_extrusion_width = 0.4
+top_solid_layers = 7
+
+ # M2, M3, U1
+[print:0.15mm Normal @0.25 nozzle MakerGear]
+inherits = *0.15mm*; *0.25nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.25
+
+# M2, M3, U1
+[print:0.15mm Quality @0.35 nozzle MakerGear]
+inherits = *0.15mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.35
+bridge_flow_ratio = 0.95
+
+# Micro
+[print:0.15mm Quality @0.40 nozzle MakerGear]
+inherits = *0.15mm*; *0.40nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_MICRO.*/ and nozzle_diameter[0]==0.40
+first_layer_height = 0.2
+
+# ---------------------------
+# 0.20mm
+# ---------------------------
+[print:*0.20mm*]
+inherits = *common*
+bottom_solid_layers = 2
+bridge_flow_ratio = 0.9
+external_perimeter_speed = 60
+infill_speed = 65
+layer_height = 0.2
+perimeter_speed = 50
+solid_infill_speed = 50
+top_solid_layers = 3
+
+# M2, M3, U1
+[print:0.20mm Quality @0.50 nozzle MakerGear]
+inherits = *0.20mm*; *0.50nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.50
+
+# M2, M3, U1
+[print:0.20mm Normal @0.35 nozzle MakerGear]
+inherits = *0.20mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.35
+bridge_flow_ratio = 0.95
+
+# Micro
+[print:0.20mm Normal @0.40 Nozzle MakerGear]
+inherits = *0.20mm*; *0.40nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_MICRO.*/ and nozzle_diameter[0]==0.40
+perimeters = 3
+
+# ---------------------------
+# 0.25mm (Testing)
+# ---------------------------
+[print:*0.25mm*]
+inherits = *common*
+bottom_solid_layers = 4
+bridge_flow_ratio = 0.95
+external_perimeter_speed = 40
+layer_height = 0.25
+perimeter_acceleration = 800
+perimeter_speed = 50
+top_solid_layers = 4
+
+# M2, M3, U1
+[print:0.25mm Speed @0.35 nozzle MakerGear]
+inherits = *0.25mm*
+bridge_speed = 60
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.35
+external_perimeter_speed = 70
+infill_acceleration = 2000
+infill_speed = 200
+max_print_speed = 200
+perimeter_speed = 75
+solid_infill_speed = 200
+top_solid_infill_speed = 70
+
+# Micro
+[print:0.25mm Fast @0.40 nozzle MakerGear]
+inherits = *0.25mm*; *0.40nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_MICRO.*/ and nozzle_diameter[0]==0.40
+perimeters = 3
+
+# M2, M3, U1
+[print:0.25mm Normal @0.50 nozzle MakerGear]
+inherits = *0.25mm*; *0.50nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.50
+first_layer_height = 0.26
+
+# M2, M3, U1
+[print:0.25mm Quality @0.75 nozzle MakerGear]
+inherits = *0.25mm*; *0.75nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.75
+
+# ---------------------------
+# 0.30mm
+# ---------------------------
+[print:*0.30mm*]
+inherits = *common*
+bottom_solid_layers = 3
+bridge_flow_ratio = 0.95
+external_perimeter_speed = 75
+first_layer_height = 0.24
+gap_fill_speed = 40
+infill_speed = 80
+layer_height = 0.3
+perimeter_speed = 65
+small_perimeter_speed = 35
+solid_infill_speed = 50
+support_material_contact_distance = 0.3
+top_infill_extrusion_width = 0.4
+top_solid_layers = 4
+
+ # M2, M3, U1
+[print:0.30mm Speed @0.50 nozzle MakerGear]
+inherits = *0.30mm*; *0.50nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.50
+first_layer_height = 0.22
+
+# M2, M3, U1
+[print:0.30mm Normal @0.75 nozzle MakerGear]
+inherits = *0.30mm*; *0.75nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.75
+
+# ---------------------------
+# 0.35mm (Testing)
+# ---------------------------
+[print:*0.35mm*]
+inherits = *common*
+bottom_solid_layers = 3
+external_perimeter_extrusion_width = 0.6
+external_perimeter_speed = 40
+first_layer_extrusion_width = 0.75
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.35
+perimeter_acceleration = 800
+perimeter_extrusion_width = 0.65
+perimeter_speed = 50
+solid_infill_extrusion_width = 0.65
+solid_infill_speed = 60
+top_solid_infill_speed = 50
+top_solid_layers = 4
+
+# [print:NOT READY 0.35mm Speed @0.50 nozzle MakerGear]
+#inherits = *0.35*; *0.50nozzle*
+# compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.50
+
+# M2, M3, U1
+[print:0.35mm Speed @0.75 nozzle MakerGear]
+inherits = *0.35mm*; *0.75nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.75
+
+# ---------------------------
+# 0.40mm (NOT READY)
+# ---------------------------
+[print:*0.40mm*]
+inherits = *common*
+bottom_solid_layers = 3
+external_perimeter_extrusion_width = 0.6
+external_perimeter_speed = 40
+first_layer_extrusion_width = 0.75
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.40
+perimeter_acceleration = 800
+perimeter_extrusion_width = 0.65
+perimeter_speed = 50
+solid_infill_extrusion_width = 0.65
+solid_infill_speed = 60
+top_solid_infill_speed = 50
+top_solid_layers = 4
+
+# [print:NOT READY 0.40mm Do_I_Want_To_Support_This @0.75 nozzle] # M2, M3, U1
+# inherits = *0.40mm*; *0.75nozzle*
+# compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/ and nozzle_diameter[0]==0.75
+
+
+# /~~~~~~~~~~~~~~~~~~~~~~~~~\
+# |~~~ Filament Settings ~~~|
+# \~~~~~~~~~~~~~~~~~~~~~~~~~/
+# When submitting new filaments please print the following temperature tower at 0.1mm layer height:
+#   https://www.thingiverse.com/thing:2615842
+# Pay particular attention to bridging, overhangs and retractions.
+# Also print the following bed adhesion test at 0.1 layer height as well:
+#   https://www.prusaprinters.org/prints/4634-bed-adhesion-warp-test
+
+[filament:*common*]
+compatible_printers = 
+cooling = 0
+extrusion_multiplier = 0.9
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 15
+slowdown_below_layer_time = 20
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+bridge_fan_speed = 100
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(ICRO|2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+disable_fan_first_layers = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #DDDDDD
+filament_cost = 20
+filament_density = 1.24
+filament_max_volumetric_speed = 15
+filament_type = PLA
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 210
+
+[filament:*PET*]
+inherits = *common*
+bed_temperature = 70
+bridge_fan_speed = 100
+cooling = 1
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+disable_fan_first_layers = 2
+extrusion_multiplier = 0.98
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_colour = #DDDDDD
+filament_cost = 30
+filament_density = 1.27
+filament_max_volumetric_speed = 8
+filament_type = PETG
+first_layer_bed_temperature = 70
+first_layer_temperature = 250
+max_fan_speed = 80
+min_fan_speed = 40
+temperature = 245
+
+[filament:*ABS*]
+inherits = *common*
+bed_temperature = 100
+bridge_fan_speed = 30
+cooling = 0
+disable_fan_first_layers = 0
+extrusion_multiplier = 1
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #DDDDDD
+filament_cost = 20
+filament_density = 1.04
+filament_max_volumetric_speed = 11
+filament_type = ABS
+first_layer_bed_temperature = 110
+first_layer_temperature = 250
+max_fan_speed = 0
+min_fan_speed = 0
+temperature = 245
+top_fan_speed = 0
+
+[filament:*FLEX*]
+inherits = *common*
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 0
+disable_fan_first_layers = 3
+extrusion_multiplier = 1.15
+fan_always_on = 0
+fan_below_layer_time = 100
+filament_colour = #008000
+filament_deretract_speed = 25
+filament_max_volumetric_speed = 2
+filament_retract_length = 0.8
+filament_retract_lift = 0
+filament_type = FLEX
+filament_wipe = 0
+first_layer_bed_temperature = 55
+first_layer_temperature = 245
+max_fan_speed = 90
+min_fan_speed = 70
+slowdown_below_layer_time = 10
+temperature = 240
+
+[filament:*EMPTY*]
+inherits = *common*
+bed_temperature = 
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2_DUAL|3_ID)).*/
+filament_colour = #DDDDDD
+filament_cost = 0
+filament_density = 0
+filament_type = EMPTY
+first_layer_bed_temperature = 
+first_layer_temperature = 0
+temperature = 0
+
+# ---------------------------
+# PLA Filament
+# ---------------------------
+[filament:MakerGear PLA @MakerGear]
+inherits = *PLA*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes!~/.*PRINTER_MODEL_MAKERGEAR_MICRO.*/
+filament_cost = 25.4
+filament_density = 1.24
+filament_vendor = MakerGear
+
+
+[filament:MakerGear Translucent PLA @MakerGear]
+inherits = MakerGear PLA @MakerGear
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/
+filament_cost = 25.4
+filament_density = 1.24
+filament_vendor = MakerGear
+
+[filament:MakerGear PLA @MakerGear_Micro]
+inherits = *PLA*
+bed_temperature = 
+bridge_fan_speed = 0
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_MICRO.*/
+cooling = 0
+disable_fan_first_layers = 
+fan_always_on = 0
+fan_below_layer_time = 
+filament_colour = #DDDDDD
+filament_cost = 20
+filament_density = 1.24
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_vendor = MakerGear
+first_layer_bed_temperature = 0
+first_layer_temperature = 210
+max_fan_speed = 
+min_fan_speed = 
+temperature = 205
+
+[filament:Fiberlogy PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.24
+filament_vendor = Fiberlogy
+
+[filament:AmazonBasics PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.24
+filament_vendor = AmazonBasics
+
+[filament:Overture PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 22
+filament_density = 1.24
+filament_spool_weight = 235
+filament_vendor = Overture
+
+[filament:Hatchbox PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.27
+filament_spool_weight = 245
+filament_vendor = Hatchbox
+
+[filament:Fillamentum PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 35.48
+filament_density = 1.24
+filament_spool_weight = 230
+filament_vendor = Fillamentum
+
+[filament:Esun PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.24
+filament_spool_weight = 265
+filament_vendor = Esun
+
+[filament:Inland PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.24
+filament_spool_weight = 265
+filament_vendor = Inland
+
+[filament:MatterHackers PLA @MakerGear]
+inherits = *PLA*
+filament_cost = 25.4
+filament_density = 1.24
+filament_spool_weight = 265
+filament_vendor = MatterHackers
+
+# ---------------------------
+# ABS Filament
+# ---------------------------
+[filament:MakerGear ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 0
+filament_colour = #DDDDDD
+filament_density = 1.04
+filament_type = ABS
+filament_vendor = MakerGear
+
+[filament:Esun ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.82
+filament_density = 1.01
+filament_spool_weight = 265
+filament_vendor = Esun
+
+[filament:Hatchbox ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.82
+filament_density = 1.04
+filament_spool_weight = 245
+filament_vendor = Hatchbox
+
+[filament:Verbatim ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 25.87
+filament_density = 1.05
+filament_vendor = Verbatim
+
+[filament:Fillamentum ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 32.4
+filament_density = 1.04
+filament_spool_weight = 230
+filament_vendor = Fillamentum
+first_layer_temperature = 240
+temperature = 240
+
+[filament:E3D PC-ABS @MakerGear]
+inherits = *ABS*
+filament_vendor = E3D
+filament_cost = 0
+filament_type = PC
+filament_density = 1.05
+first_layer_temperature = 275
+temperature = 270
+
+# ---------------------------
+# ASA Filament
+# ---------------------------
+[filament:Fillamentum ASA @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+fan_always_on = 1
+filament_cost = 38.7
+filament_density = 1.07
+filament_spool_weight = 230
+filament_type = ASA
+filament_vendor = Fillamentum
+first_layer_temperature = 265
+max_fan_speed = 20
+min_fan_speed = 20
+min_print_speed = 15
+slowdown_below_layer_time = 15
+temperature = 265
+
+[filament:Fiberlogy ASA @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_vendor = Fiberlogy
+filament_cost = 33
+filament_density = 1.07
+filament_spool_weight = 330
+fan_always_on = 0
+cooling = 1
+min_fan_speed = 10
+max_fan_speed = 15
+bridge_fan_speed = 30
+min_print_speed = 15
+slowdown_below_layer_time = 15
+first_layer_temperature = 260
+temperature = 260
+first_layer_bed_temperature = 105
+bed_temperature = 110
+filament_type = ASA
+fan_below_layer_time = 30
+disable_fan_first_layers = 5
+
+# ---------------------------
+# PETG Filament
+# ---------------------------
+[filament:Verbatim PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = Verbatim
+
+[filament:Fiberlogy PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 21.50
+filament_density = 1.27
+filament_vendor = Fiberlogy
+
+[filament:Esun PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 21.50
+filament_density = 1.27
+filament_vendor = Esun
+
+[filament:Overture PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = Overture
+
+[filament:3DxTech PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = 3DxTech
+
+[filament:Hatchbox PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = Hatchbox
+
+[filament:Inland PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = Inland
+
+[filament:MatterHackers PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+filament_vendor = MatterHackers
+
+# ---------------------------
+# Nylon Filament
+# ---------------------------
+[filament:Fiberlogy Nylon PA12 @MakerGear]
+inherits = Fiberlogy ASA @MakerGear
+bed_temperature = 105
+bridge_fan_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_cost = 48
+filament_density = 1.01
+filament_max_volumetric_speed = 6
+filament_retract_lift = 0.2
+filament_type = NYLON
+first_layer_bed_temperature = 110
+first_layer_temperature = 265
+max_fan_speed = 15
+min_fan_speed = 10
+temperature = 265
+
+[filament:Fiberlogy Nylon PA12+CF15 @MakerGear]
+inherits = Fiberlogy Nylon PA12 @MakerGear
+bed_temperature = 110
+bridge_fan_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+extrusion_multiplier = 0.97
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_cost = 87.5
+filament_density = 1.07
+filament_max_volumetric_speed = 6
+first_layer_bed_temperature = 105
+first_layer_temperature = 265
+max_fan_speed = 15
+min_fan_speed = 10
+temperature = 265
+# ---------------------------
+# Flex Filament
+# ---------------------------
+[filament:AmazonBasics TPU @MakerGear]
+inherits = *FLEX*
+bed_temperature = 50
+bridge_fan_speed = 100
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+disable_fan_first_layers = 4
+extrusion_multiplier = 1.14
+fan_always_on = 1
+filament_cost = 19.99
+filament_density = 1.21
+filament_deretract_speed = 20
+filament_max_volumetric_speed = 1.8
+filament_retract_before_travel = 3
+filament_retract_length = 2
+filament_retract_lift = 0
+filament_retract_speed = 45
+filament_vendor = AmazonBasics
+filament_wipe = 0
+first_layer_bed_temperature = 50
+first_layer_temperature = 235
+full_fan_speed_layer = 6
+max_fan_speed = 80
+min_fan_speed = 80
+min_print_speed = 15
+temperature = 235
+
+[filament:SainSmart TPU @MakerGear]
+inherits = *FLEX*
+bed_temperature = 50
+bridge_fan_speed = 100
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+disable_fan_first_layers = 4
+extrusion_multiplier = 1.1
+fan_always_on = 1
+filament_cost = 32.99
+filament_density = 1.21
+filament_deretract_speed = 25
+filament_max_volumetric_speed = 2.5
+filament_retract_before_travel = 3
+filament_retract_length = 1
+filament_retract_lift = 0
+filament_retract_speed = nil
+filament_vendor = SainSmart
+filament_wipe = 0
+first_layer_bed_temperature = 50
+first_layer_temperature = 230
+full_fan_speed_layer = 6
+max_fan_speed = 80
+min_fan_speed = 80
+min_print_speed = 15
+temperature = 230
+
+# ---------------------------
+# Misc Filament
+# ---------------------------
+[filament:PolyMaker PolySmooth @MakerGear]
+inherits = *PLA*
+bed_temperature = 60
+bridge_fan_speed = 100
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+disable_fan_first_layers = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #666666
+filament_cost = 20
+filament_density = 1.24
+filament_max_volumetric_speed = 10
+filament_retract_length = 1
+filament_retract_speed = 25
+filament_type = Misc
+filament_vendor = PolyMaker
+first_layer_bed_temperature = 55
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 210
+
+[filament:Empty @MakerGear]
+inherits = *EMPTY*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2_DUAL|3_ID)).*/
+filament_cost = 0
+filament_density = 0
+filament_spool_weight = 0
+filament_vendor = MakerGear
+filament_type = Misc
+
+# ---------------------------
+# Generic Filament
+# ---------------------------
+[filament:Generic ABS @MakerGear]
+inherits = *ABS*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.82
+filament_density = 1.04
+filament_vendor = Generic
+
+[filament:Generic PETG @MakerGear]
+inherits = *PET*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.82
+filament_density = 1.27
+filament_vendor = Generic
+
+
+[filament:Generic ASA @MakerGear]
+inherits = *ABS*
+bed_temperature = 90
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 27.82
+filament_density = 1.04
+filament_type = ASA
+filament_vendor = Generic
+first_layer_bed_temperature = 95
+first_layer_temperature = 250
+temperature = 245
+
+[filament:Generic FLEX @MakerGear]
+inherits = *FLEX*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+filament_cost = 82
+filament_density = 1.22
+filament_max_volumetric_speed = 1.2
+filament_retract_length = 0
+filament_retract_lift = nil
+filament_retract_speed = nil
+filament_vendor = Generic
+
+[filament:Generic HIPS @MakerGear]
+inherits = *ABS*
+bridge_fan_speed = 50
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_MAKERGEAR.*/ and printer_notes=~/.*PRINTER_MODEL_MAKERGEAR_(U1|M(2|2_DUAL|3_SE|3_ID|3_ID_DUPLICATION)).*/
+cooling = 1
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 10
+filament_colour = #FFFFD7
+filament_cost = 27.3
+filament_density = 1.04
+filament_soluble = 1
+filament_type = HIPS
+filament_vendor = Generic
+first_layer_temperature = 230
+max_fan_speed = 20
+min_fan_speed = 20
+temperature = 230
+
+# /~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\
+# |~~~ Common printer presets ~~~|
+# \~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~/
+[printer:*default*]
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\n\n
+between_objects_gcode = 
+color_change_gcode = 
+extruder_colour = #FD8309;#E1E1E1
+extruder_offset = 0x0
+gcode_flavor = marlin
+layer_gcode = ;AFTER_LAYER_CHANGE\n;[layer_z]
+machine_limits_usage = time_estimate_only
+nozzle_diameter = 0.35
+octoprint_apikey = 
+octoprint_host = 
+pause_print_gcode = M601
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\n
+printer_settings_id = 
+printer_technology = FFF
+remaining_times = 0
+retract_length = 2
+serial_port = 
+serial_speed = 115200
+silent_mode = 0
+use_firmware_retraction = 0
+use_relative_e_distances = 0
+use_volumetric_e = 0
+variable_layer_height = 0
+
+# ---------------------------
+# MakerGear Micro
+# ---------------------------
+[printer:MakerGear Micro]
+inherits = *default*
+bed_shape = 0x0, 81x0, 81x81, 0x81
+default_filament_profile = "MakerGear PLA @MakerGear_Micro"
+default_print_profile = 0.20mm Normal @0.40 Nozzle MakerGear
+end_gcode = M104 S0 ; Turn off hotend temperature \nG1 X0 Y81 Z95
+gcode_flavor = marlin
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 2000, 2000
+machine_max_acceleration_retracting = 2000, 2000
+machine_max_acceleration_x = 450, 450
+machine_max_acceleration_y = 450, 450
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 20, 20
+machine_max_jerk_e = 10, 10
+# machine_max_jerk_x = Using Junction Deviation Factor
+# machine_max_jerk_y = Using Junction Deviation Factor
+# machine_max_jerk_z = Using Junction Deviation Factor
+max_layer_height = 0.3
+max_print_height = 100
+nozzle_diameter = 0.40
+printer_model = MAKERGEAR_MICRO
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_MICRO\n 
+printer_variant = 0.40
+retract_length = 6
+retract_speed = 60
+start_gcode = G90 ; blank \nM82 ; blank \nG28 ; home all axes \nG29 ; Mesh testing \nG1 X0 Y0 ; moves axes \nM109 S[first_layer_temperature_[current_extruder]] ; wait for hotend to reach first layer temperature
+# thumbnails = 16x16, 261x256
+
+# ---------------------------
+# MakerGear M2
+# ---------------------------
+[printer:MakerGear M2 (V4 Hotend)]
+inherits = *default*
+bed_shape = 0x0,200x0,200x251,0x251
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+end_gcode = M104 S0 ; turn off extruder\nM140 S0 ; turn off bed\nG91 ; relative mode\nG1 Z10 ; lift 10mm\nG90 ; absolute mode\nG28 X0 ; home X axis\nM84 ; disable motors
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 2000, 2000
+machine_max_acceleration_retracting = 3000, 3000
+machine_max_acceleration_x = 2000, 2000
+machine_max_acceleration_y = 2000, 2000
+machine_max_acceleration_z = 2000, 2000
+machine_max_feedrate_e = 25, 25
+machine_max_feedrate_x = 200, 200
+machine_max_feedrate_y = 200, 200
+machine_max_feedrate_z = 25, 25
+machine_max_jerk_e = 1, 1
+machine_max_jerk_x = 4, 4
+machine_max_jerk_y = 4, 4
+machine_max_jerk_z = 0.4, 0.4
+max_print_height = 200
+nozzle_diameter = 0.35
+printer_model = MAKERGEAR_M2
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M2\n 
+printer_variant = 0.35
+start_gcode = M108 S255 ; turn on M2 fans\nG28 ; home all axes\nG1 Y50 F6000 ; move forward to avoid binder clips\nG1 X205 Z10 ; move off platform\nG1 Z0.4 ; position nozzle\nG92 E0 ; zero extruder\nM109 S[first_layer_temperature_[current_extruder]]\nG1 E25 F225 ; purge nozzle\nG92 E0 ; zero extruder\nG1 X190 Z0.1 E1.0 F1200 ; slow wipe\nG1 X180 Z0.25 ; lift\n
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear M2 0.25 Nozzle]
+inherits = MakerGear M2 (V4 Hotend)
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M2 0.50 Nozzle]
+inherits = MakerGear M2 (V4 Hotend)
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.50
+printer_variant = 0.50
+
+[printer:MakerGear M2 0.75 Nozzle]
+inherits = MakerGear M2 (V4 Hotend)
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.15
+nozzle_diameter = 0.75
+printer_variant = 0.75
+retract_length = 1
+retract_speed = 35
+
+# -------------------------------
+# MakerGear M2 Dual
+# -------------------------------
+[printer:MakerGear M2 Dual]
+inherits = *default*
+bed_shape = 0x0,200x0,200x251,0x251
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+end_gcode = M104 S0 T1 ; turn off right extruder\nM104 S0 T0 ; turn off left extruder\nM140 S0 ; turn off bed\nG91 ; relative mode\nG1 Z10 ; lift 10mm\nG90 ; absolute mode\nG28 X0 ; home X axis\nM84 ; disable motors
+extruders_count = 2
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 1000, 1000
+machine_max_acceleration_retracting = 2000, 2000
+machine_max_acceleration_x = 1200, 1200
+machine_max_acceleration_y = 1200, 1200
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 10, 10
+machine_max_jerk_e = 10, 10
+machine_max_jerk_x = 5, 5
+machine_max_jerk_y = 5, 5
+machine_max_jerk_z = 1, 1
+max_print_height = 200
+nozzle_diameter = 0.35,0.35
+printer_model = MAKERGEAR_M2_DUAL
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M2_DUAL\n 
+printer_variant = 0.35
+start_gcode = \nM108 S0 ; Turn on M2 fans\n; Turn off hotends to reduce ooze on the bed during startup\n; NOTE: this does not explicitly wait for the hotends to completely cool down\nM104 T0 S0\nM104 T1 S0\n\n{if first_layer_bed_temperature[1] < first_layer_bed_temperature[0]}\nM140 S{first_layer_bed_temperature[0]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[0]}	   ; Wait for bed to reach temperature\n{endif}\n\n{if first_layer_bed_temperature[0] < first_layer_bed_temperature[1]}\nM140 S{first_layer_bed_temperature[1]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[1]}	   ; Wait for bed to reach temperature\n{endif}\n\nT1 ; Switch to right extruder offsets for homing\nG28 ; Home all axes\nT0 ; Switch to left extruder\nG1 X0 Y50 F6000 ; Move forward to avoid binder clips\nG1 X200 Z10 F3600 ; Move off platform\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[1]}\n\n; Wait for hotends to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[1]}\n\n\n{if temperature[1] == 0}\n; Single Mode - Left Purge script\n\nG1 Z0.4 ; Position nozzle above buildplate\nG92 E0 ; Zero extruder\nG1 E25 F225 ; Purge left extruder\nG92 E0 ; Zero extruder\nG1 X160 Z0.1 E1.0 F1200 ; Slow wipe\nG1 X140 Z0.25 ; Lift\n{endif}\n\n{if temperature[0] == 0}\n; Single Mode - Right Purge Script\n\nG1 Z0.4 ; Position nozzle above buildplate\nT1 ; Switch to right extruder\nG92 E0 ; Zero extruder\nG1 E25 F225 ; Purge right extruder\nG92 E0 ; Zero extruder\nG1 X160 Z0.1 E1.0 F1200 ; Slow wipe\nG1 X140 Z0.25 ; Lift\n{endif}\n\n{if temperature[0] > 0 and temperature[1] > 0}\n; Dual Mode - Purge Script\nG1 Z0.4 ; Position nozzle above buildplate\nG92 E0 ; Zero extruder\nG1 E25 F225 ; Purge left extruder\nG92 E0 ; Zero extruder\nT1 ; Set right extruder\nG1 E25 F225 ; Purge right extruder\nG92 E0 ; Zero extruder\nG1 X160 Z0.1 E1.0 F1200 ; Slow wipe\nG1 X140 Z0.25 ; Lift\nT0\nG92 E0 ; Zero extruder\n{endif}
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear M2 Dual 0.25 Nozzle]
+inherits = MakerGear M2 Dual
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M2 Dual 0.50 Nozzle]
+inherits = MakerGear M2 Dual
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.50
+printer_variant = 0.50
+
+[printer:MakerGear M2 Dual 0.75 Nozzle]
+inherits = MakerGear M2 Dual
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.15,0.15
+nozzle_diameter = 0.75,0.75
+printer_variant = 0.75
+retract_length = 1, 1
+retract_speed = 35, 35
+
+# ---------------------------
+# MakerGear M3-S3
+# ---------------------------
+[printer:MakerGear M3 Single Extruder]
+inherits = *default*
+bed_shape = 0x0,200x0,200x251,0x251
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+end_gcode = M104 S0 ; turn off extruder\nM104 S0 ; turn off extruder\nM140 S0 ; turn off bed\nG1 Z200 Y0 X215 F10000\nM106 S0\nM84 ; disable motors
+host_type = octoprint
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 1000, 1000
+machine_max_acceleration_retracting = 2000, 2000
+machine_max_acceleration_x = 1200, 1200
+machine_max_acceleration_y = 1200, 1200
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 10, 10
+machine_max_jerk_e = 10, 10
+machine_max_jerk_x = 5, 5
+machine_max_jerk_y = 5, 5
+machine_max_jerk_z = 1, 1
+max_print_height = 200
+nozzle_diameter = 0.35
+printer_model = MAKERGEAR_M3_SE
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M3_SE\n 
+printer_variant = 0.35
+start_gcode = G28 ; home all axes\nG1 X215 Y40 Z0.1 F10000 ; move off the bed and bring the bed up\nM109 S[first_layer_temperature_[current_extruder]]\nG92 E0 ; zero extruder\nG1 X195 Z0.1 F1000; scrape off any ooze\nG1 Z5 ; lift\nG1 X170 Y3 F10000; move to unused front edge\nG1 Z0.30 F1000\nG1 X40 E20 F1000\nG1 X30 Z0.05 F1000 ; wipe off tail\nG1 Z1\nG92 E0\nM211 S0 ;disable software endstops\n; ok now you can start 
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear M3 Single Extruder 0.25 Nozzle]
+inherits = MakerGear M3 Single Extruder
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M3 Single Extruder 0.50 Nozzle]
+inherits = MakerGear M3 Single Extruder
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.50
+printer_variant = 0.50
+
+[printer:MakerGear M3 Single Extruder 0.75 Nozzle]
+inherits = MakerGear M3 Single Extruder
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.25
+nozzle_diameter = 0.75
+printer_variant = 0.75
+retract_length = 1
+retract_speed = 35
+
+# ------------------------------
+# MakerGear M3 Independent Dual Rev.0
+# ------------------------------
+[printer:MakerGear M3 Independent Dual Rev.0]
+inherits = *default*
+bed_shape = 0x0,200x0,200x255,0x251
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+end_gcode = M104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1; turn off extruder\nM140 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm if possible Max endstop will catch it if it is to far\nG90;  absolute mode\nG28 X ; home tool/s\nT0 ; defualt tool should always be T0\nG1 Y230 F10000 ; move build plate out\nM84 ; disable motors
+extruders_count = 2
+extruder_offset = 0x0,0x0
+host_type = octoprint
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 1000, 1000
+machine_max_acceleration_retracting = 2000, 2000
+machine_max_acceleration_x = 1200, 1200
+machine_max_acceleration_y = 1200, 1200
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 10, 10
+machine_max_jerk_e = 10, 10
+machine_max_jerk_x = 5, 5
+machine_max_jerk_y = 5, 5
+machine_max_jerk_z = 1, 1
+max_layer_height = 0.28,0.28
+max_print_height = 200
+nozzle_diameter = 0.35,0.35
+printer_model = MAKERGEAR_M3_ID_0_DUPLICATION
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M3_ID_0\n 
+printer_variant = 0.35
+retract_length_toolchange = 4,4
+start_gcode = ;M3 Independent Dual Startup Script\n\n; Turn off hotends to reduce ooze on the bed during startup\n; NOTE: this does not explicitly wait for the hotends to completely cool down\nM104 T0 S0\nM104 T1 S0\n\n{if first_layer_bed_temperature[1] < first_layer_bed_temperature[0]}\nM140 S{first_layer_bed_temperature[0]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[0]}	; Wait for bed to reach temperature\n{endif}\n\n{if first_layer_bed_temperature[0] < first_layer_bed_temperature[1]}\nM140 S{first_layer_bed_temperature[1]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[1]}	; Wait for bed to reach temperature\n{endif}\n\nM605 S0    ; Set to full independent control on x axes\nT0         ; Switch to left hotend\nG28        ; Home all axes probe/mesh if available\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[1]}\n\n; Wait for hotends to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[1]}\n\n; Purge Scripts\n{if temperature[1] == 0}\n\n; Single Mode - Left Purge\nM211 S0 ; Turn off software endstops\nG1 X205 Y210 Z0.1 F10000 ; Move off the bed and bring the bed up\nG92 E0 ; Zero extruder\nG1 X195 Z0.1 F1000 ; Scrape off any ooze\nG1 Z10 ; Lift bed\nG1 X160 Y240 F10000 ; move to unused front edge\nG1 Z0.30 F1000\nG1 X40 E20 F1000\nG1 X30 Z0.05 F1000 ; wipe off tail\nG1 Z10\nG92 E0{endif}\n\n{if temperature[0] == 0}\n; Single Mode - Right Purge\nM211 S0 ; Turn off software endstops for purge moves\nG1 X25 F9000 ; Move T0 past bedclips as to not damage probe\nT1 ; Switch to right hotend\nG1 X205 Y210 Z0.1 F10000 ; Move off the bed and bring the bed up\nG92 E0 ; Zero extruder\nG1 X195 Z0.1 F1000 ; Scrape off any ooze\nG1 Z10 ; Lift\nG1 X100 Y240 F10000 ; Move to unused front edge\nG1 Z0.30 F1000\nG1 X180 E9.25  F1000 ; Deposit extrusion line\nG1 Y239  E9.45 F1000 ; Move Y-axis and extrude\nG1 X130 E17.05; lift \nF1000 ; deposit extrusion line\nG1 X120 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y230 ; move back to safe bounds\nT0\nG1 X-20.77 ; move T0 back home\nT1{endif}\n\n{if temperature[0] > 0 and temperature[1] > 0}\n; M3-ID T0/T1 Starting Script\nG1 X25 F9000; move T0 past bedclips as to not damage probe\n\nT1 ; Switch to right extruder\nG1 X215 Y210 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 X195 Z0.1 F1000; scrape off any ooze\nG1 Z10 ; lift\nM211 S0 ; turn off soft endstops for purge moves\nG1 X100 Y240 F10000; move to unused back edge\nG1 Z0.30 F1000\nG1 X180 E9.25  F1000; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X130 E17.05; lift F1000; deposit extrusion line\nG1 X100 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y225 ; move back to safe bounds\nG1 X252 F4800; move T1 home\n\nT0;\nG1 X205 Y210 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 X195 Z0.1 F1000; scrape off any ooze\nG1 Z10 ; lift\nG1 X100 Y240 F10000; move to unused back edge\nG1 Z0.30 F1000\nG1 X20 E9.25  F1000; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X70 E17.05; lift F1000; deposit extrusion line\nG1 X100 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y225 ; move back to safe bounds\nG1 X-20.77 F4800 ; move T0 home\nG92 E0{endif}\n; ok now you can start
+toolchange_gcode = {if next_extruder == 0}\nT1 ; makes sure T1 is active\nG90 ; switch into absolute mode\nG1 X252\nT0\n{endif}\n\n{if next_extruder == 1}\nT0 ; makes sure T0 is active\nG90 ; switch into absolute mode\nG1 X-4\nT1\n{endif}\n
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.25 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.0
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15,0.15
+min_layer_height = 0.05,0.05
+nozzle_diameter = 0.25,0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.50 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.0
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35,0.35
+min_layer_height = 0.1,0.1
+nozzle_diameter = 0.50,0.50
+printer_variant = 0.50
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.75 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.0
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5,0.5
+min_layer_height = 0.15,0.15
+nozzle_diameter = 0.75,0.75
+printer_variant = 0.75
+retract_length = 1, 1
+retract_speed = 35, 35
+
+# -----------------------------------
+# MakerGear M3-ID (Duplication Mode)
+# -----------------------------------
+[printer:MakerGear M3 Independent Dual Rev.0 (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.0
+bed_shape = 0x0,100x0,100x251,0x251
+end_gcode = M605 S0 ; set to full independent control\nM104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1 ; turn off extruder\nM140 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm if possible Max endstop will catch it if it is to far\nG90 ;  absolute mode\nG28 X ; home tools\nT0 ; default tool should always be T0\nG1 Y230 F10000 ; move build plate out\nM84 ; disable motors
+extruders_count = 1
+nozzle_diameter = 0.35
+printer_model = MAKERGEAR_M3_ID_0_DUPLICATION
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M3_ID_0_DUPLICATION\n 
+printer_variant = 0.35
+start_gcode = ;M3 ID Duplication Mode startup script\nM211 S1 ; turn on soft endstops to protect the machine\nM605 S0 ; set to full independent control on x axes\nG28 XYZ ; home without mesh level compensation\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[0]}\n\n; Wait for hotend's to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[0]}\n\nT0 ; Make sure we're on T0\nM605 S2 R0 X100 ; set X to duplication mode 0 temperature difference 100 X difference\nG28 X ; home x axes to engange mode\nM211 S0 ; turn off soft endstops to let us move to back of the bed\nG1 X20 F1000 ; move to start x position\nG1 Y243 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 Y240 Z0.1 F1000 ; scrape off any ooze\nG1 Z0.30 F1000 ; lift\nG1 X80 E9.25 ; lift F1000 ; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X30 E17.05 ; lift F1000 ; deposit extrusion line\nG1 X20 Z0.05 F1000 ; wipe off tail\nG1 Z10 Y223 ; lift to avoid clips and move back to safe bounds\nM400 ; wait for moves to finish before proceeding so that T1 doesn't get caught in a deadzone when switching back to Soft endstops on \n;\n;\nM211 S0 ; turn off soft endstops  \nG92 E0; zero extruder
+# thumbnails = 16x16,300x350
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.25 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.0 (Duplication Mode)
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.50 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.0 (Duplication Mode)
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.50
+printer_variant = 0.50
+
+[printer:MakerGear M3 Independent Dual Rev.0 0.75 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.0 (Duplication Mode)
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.15
+nozzle_diameter = 0.75
+printer_variant = 0.75
+retract_length = 1
+retract_speed = 35
+
+# ------------------------------
+# MakerGear M3 Independent Dual Rev.1
+# ------------------------------
+[printer:MakerGear M3 Independent Dual Rev.1]
+inherits = *default*
+bed_shape = 0x0,200x0,200x251,0x251
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+end_gcode = M104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1; turn off extruder\nM140 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm if possible Max endstop will catch it if it is to far\nG90;  absolute mode\nG28 X ; home tool/s\nT0 ; defualt tool should always be T0\nG1 Y230 F10000 ; move build plate out\nM84 ; disable motors
+extruders_count = 2
+extruder_offset = 0x0,0x0
+host_type = octoprint
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 1000, 1000
+machine_max_acceleration_retracting = 2000, 2000
+machine_max_acceleration_x = 1200, 1200
+machine_max_acceleration_y = 1200, 1200
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 10, 10
+machine_max_jerk_e = 10, 10
+machine_max_jerk_x = 5, 5
+machine_max_jerk_y = 5, 5
+machine_max_jerk_z = 1, 1
+max_layer_height = 0.28,0.28
+max_print_height = 200
+nozzle_diameter = 0.35,0.35
+printer_model = MAKERGEAR_M3_ID_1
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M3_ID_1\n 
+printer_variant = 0.35
+retract_length_toolchange = 4,4
+start_gcode = ;M3 Independent Dual Startup Script\n\n; Turn off hotends to reduce ooze on the bed during startup\n; NOTE: this does not explicitly wait for the hotends to completely cool down\nM104 T0 S0\nM104 T1 S0\n\n{if first_layer_bed_temperature[1] < first_layer_bed_temperature[0]}\nM140 S{first_layer_bed_temperature[0]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[0]}	; Wait for bed to reach temperature\n{endif}\n\n{if first_layer_bed_temperature[0] < first_layer_bed_temperature[1]}\nM140 S{first_layer_bed_temperature[1]}     ; Set bed temperature\nM190 S{first_layer_bed_temperature[1]}	; Wait for bed to reach temperature\n{endif}\n\nM605 S0    ; Set to full independent control on x axes\nT0         ; Switch to left hotend\nG28        ; Home all axes probe/mesh if available\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[1]}\n\n; Wait for hotends to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[1]}\n\n; Purge Scripts\n{if temperature[1] == 0}\n\n; Single Mode - Left Purge\nM211 S0 ; Turn off software endstops\nG1 X205 Y210 Z0.1 F10000 ; Move off the bed and bring the bed up\nG92 E0 ; Zero extruder\nG1 X195 Z0.1 F1000 ; Scrape off any ooze\nG1 Z10 ; Lift bed\nG1 X160 Y240 F10000 ; move to unused front edge\nG1 Z0.30 F1000\nG1 X40 E20 F1000\nG1 X30 Z0.05 F1000 ; wipe off tail\nG1 Z10\nG92 E0{endif}\n\n{if temperature[0] == 0}\n; Single Mode - Right Purge\nM211 S0 ; Turn off software endstops for purge moves\nG1 X25 F9000 ; Move T0 past bedclips as to not damage probe\nT1 ; Switch to right hotend\nG1 X205 Y210 Z0.1 F10000 ; Move off the bed and bring the bed up\nG92 E0 ; Zero extruder\nG1 X195 Z0.1 F1000 ; Scrape off any ooze\nG1 Z10 ; Lift\nG1 X100 Y240 F10000 ; Move to unused front edge\nG1 Z0.30 F1000\nG1 X180 E9.25  F1000 ; Deposit extrusion line\nG1 Y239  E9.45 F1000 ; Move Y-axis and extrude\nG1 X130 E17.05; lift \nF1000 ; deposit extrusion line\nG1 X120 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y230 ; move back to safe bounds\nT0\nG1 X-20.77 ; move T0 back home\nT1{endif}\n\n{if temperature[0] > 0 and temperature[1] > 0}\n; M3-ID T0/T1 Starting Script\nG1 X25 F9000; move T0 past bedclips as to not damage probe\n\nT1 ; Switch to right extruder\nG1 X215 Y210 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 X195 Z0.1 F1000; scrape off any ooze\nG1 Z10 ; lift\nM211 S0 ; turn off soft endstops for purge moves\nG1 X100 Y240 F10000; move to unused back edge\nG1 Z0.30 F1000\nG1 X180 E9.25  F1000; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X130 E17.05; lift F1000; deposit extrusion line\nG1 X100 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y225 ; move back to safe bounds\nG1 X252 F4800; move T1 home\n\nT0;\nG1 X205 Y210 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 X195 Z0.1 F1000; scrape off any ooze\nG1 Z10 ; lift\nG1 X100 Y240 F10000; move to unused back edge\nG1 Z0.30 F1000\nG1 X20 E9.25  F1000; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X70 E17.05; lift F1000; deposit extrusion line\nG1 X100 Z0.05 F1000 ; wipe off tail\nG92 E0; zero extruder\nG1 Z10 Y225 ; move back to safe bounds\nG1 X-20.77 F4800 ; move T0 home\nG92 E0{endif}\n; ok now you can start
+toolchange_gcode = {if next_extruder == 0}\nT1 ; makes sure T1 is active\nG90 ; switch into absolute mode\nG1 X252\nT0\n{endif}\n\n{if next_extruder == 1}\nT0 ; makes sure T0 is active\nG90 ; switch into absolute mode\nG1 X-20.77\nT1\n{endif}\n
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.25 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.1
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15,0.15
+min_layer_height = 0.05,0.05
+nozzle_diameter = 0.25,0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.50 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.1
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35,0.35
+min_layer_height = 0.1,0.1
+nozzle_diameter = 0.50,0.50
+printer_variant = 0.50
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.75 Nozzle]
+inherits = MakerGear M3 Independent Dual Rev.1
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5,0.5
+min_layer_height = 0.15,0.15
+nozzle_diameter = 0.75,0.75
+printer_variant = 0.75
+retract_length = 1, 1
+retract_speed = 35, 35
+
+# -----------------------------------
+# MakerGear M3-ID (Duplication Mode)
+# -----------------------------------
+[printer:MakerGear M3 Independent Dual Rev.1 (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.1
+bed_shape = 0x0,100x0,100x251,0x251
+end_gcode = M605 S0 ; set to full independent control\nM104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1 ; turn off extruder\nM140 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm if possible Max endstop will catch it if it is to far\nG90 ;  absolute mode\nG28 X ; home tools\nT0 ; default tool should always be T0\nG1 Y230 F10000 ; move build plate out\nM84 ; disable motors
+extruders_count = 1
+nozzle_diameter = 0.35
+printer_model = MAKERGEAR_M3_ID_1_DUPLICATION
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_M3_ID_1_DUPLICATION\n 
+printer_variant = 0.35
+start_gcode = ;M3 ID Duplication Mode startup script\nM211 S1 ; turn on soft endstops to protect the machine\nM605 S0 ; set to full independent control on x axes\nG28 XYZ ; home without mesh level compensation\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[0]}\n\n; Wait for hotend's to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[0]}\n\nT0 ; Make sure we're on T0\nM605 S2 R0 X100 ; set X to duplication mode 0 temperature difference 100 X difference\nG28 X ; home x axes to engange mode\nM211 S0 ; turn off soft endstops to let us move to back of the bed\nG1 X20 F1000 ; move to start x position\nG1 Y243 Z0.1 F10000 ; move off the bed and bring the bed up\nG92 E0 ; zero extruder\nG1 Y240 Z0.1 F1000 ; scrape off any ooze\nG1 Z0.30 F1000 ; lift\nG1 X80 E9.25 ; lift F1000 ; deposit extrusion line\nG1 Y239  E9.45 F1000 ; move  and extrude y\nG1 X30 E17.05 ; lift F1000 ; deposit extrusion line\nG1 X20 Z0.05 F1000 ; wipe off tail\nG1 Z10 Y223 ; lift to avoid clips and move back to safe bounds\nM400 ; wait for moves to finish before proceeding so that T1 doesn't get caught in a deadzone when switching back to Soft endstops on \n;\n;\nM211 S0 ; turn off soft endstops  \nG92 E0; zero extruder
+# thumbnails = 16x16,300x350
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.25 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.1 (Duplication Mode)
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.50 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.1 (Duplication Mode)
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.50
+printer_variant = 0.50
+
+[printer:MakerGear M3 Independent Dual Rev.1 0.75 Nozzle (Duplication Mode)]
+inherits = MakerGear M3 Independent Dual Rev.1 (Duplication Mode)
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.15
+nozzle_diameter = 0.75
+printer_variant = 0.75
+retract_length = 1
+retract_speed = 35
+
+# -----------------------------------
+# MakerGear Ultra One
+# -----------------------------------
+[printer:MakerGear Ultra One]
+inherits = *default*
+bed_shape = 0x0,406x0,406x355,0x355
+default_filament_profile = "MakerGear PLA @MakerGear"
+default_print_profile = 0.20mm Quality @0.50 nozzle MakerGear
+end_gcode = M106 P2 S0 ; turn off exhaust fan\n \nM104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1; turn off extruder\nM140 P0 S0 ; turn off bed\nM140 P1 S0 ; turn off bed\nM140 P2 S0 ; turn off bed\nM140 P3 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm\nG90;  absolute mode\n\nG28 XY ; home tool/s\nM502 ; set to firmware default values\nT0 ; defualt tool should always be T0
+extruders_count = 2
+extruder_offset = 0x0,0x0
+gcode_flavor = reprapfirmware
+host_type = octoprint
+machine_max_acceleration_e = 2000, 2000
+machine_max_acceleration_extruding = 1000, 1000
+machine_max_acceleration_retracting = 1500, 1500
+machine_max_acceleration_x = 1000, 1000
+machine_max_acceleration_y = 1000, 1000
+machine_max_acceleration_z = 10, 10
+machine_max_feedrate_e = 30, 30
+machine_max_feedrate_x = 300, 300
+machine_max_feedrate_y = 300, 300
+machine_max_feedrate_z = 20, 20
+machine_max_jerk_e = 10, 10
+machine_max_jerk_x = 5, 5
+machine_max_jerk_y = 5, 5
+machine_max_jerk_z = 1, 1
+max_layer_height = 0.35,0.35
+max_print_height = 350
+nozzle_diameter = 0.50,0.50
+printer_model = MAKERGEAR_U1
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_U1\n 
+printer_variant = 0.50
+retract_length_toolchange = 4,4
+start_gcode = ;U1 Startup Script\n\nM203 X18000.00 Y18000.00 Z1200.00 U18000.00 E1800.00 ; U1 max feedrate mm/minute\n        M201 X1200 Y1200 Z10 U1200 E2000             ; U1 Maximum Acceleration axes mm/s^2\n        M204 P2000 T2000                             ; U1 Maximum Acceleration printing / travel mm/s^2\n        M566 X300 Y300 Z60 U300 E600                 ; U1  instantenous speed change 'jerk' in mm/minute\n        M593 F0                                      ; make sure dynamix acceleration is off \n\n; Turn off hotends to reduce ooze on the bed during startup\nM104 T0 S0\nM104 T1 S0\n; Note: this will not explicitly wait for the hotends to cool down\n\nM221 D0 S100  ; Extruder rate for T0 is set in the profile so set to 100%\nM221 D1 S100  ; Extruder rate for T1 is set in the profile so set to 100%\n\n{if first_layer_bed_temperature[1] < first_layer_bed_temperature[0]}\nM140 P0 S{first_layer_bed_temperature[0]}	     ; Middle bed heater strip\nM140 P1 S{first_layer_bed_temperature[0]}	     ; 2nd from left and second from right bed heater\nM140 P2 S{first_layer_bed_temperature[0]}	     ; Left bed heater strip\nM140 P3 S{first_layer_bed_temperature[0]}	     ; Right bed heater strip\n{endif}\n\n{if first_layer_bed_temperature[0] < first_layer_bed_temperature[1]}\nM140 P0 S{first_layer_bed_temperature[1]}	     ; Middle bed heater strip\nM140 P1 S{first_layer_bed_temperature[1]}	     ; 2nd from left and second from right bed heater\nM140 P2 S{first_layer_bed_temperature[1]}	     ; Left bed heater strip\nM140 P3 S{first_layer_bed_temperature[1]}	     ; Right bed heater strip\n{endif}\n\nM116 ; Wait for all bed heating pads to reach operation temperature before homing (this will wait for cooldown if there is overshoot)\nG28  ; 1)Home XY,  2)Home Z,  3)Auto Level,  4)Home Z,  5) Mesh Level\n\n; Set hotend temperature\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[1]}\n\n; Wait for hotends to reach temperature\nM109 T0 S{first_layer_temperature[0]}\nM109 T1 S{first_layer_temperature[1]}\n\nM116 ; Wait for all hotends to reach operation temperature (this will wait for cooldown if there is overshoot)\n\n; Purge Scripts\n{if temperature[1] == 0}\n; U1 Single Mode - Left Purge\nT0 		    ; implied by G28 but explicilty called here\nG1 Z20.0 F6000      ; Move Z to 20\nG92 E0              ; Zero Extruder\nM564 S0 	    ; Safteys off\nG1 X160 Y5 F1000    ; Move to unused front edge\nG1 Z0.30 F1000      ; Move closer to the bed\nG1 X40 E20 F1000    ; Deposit purge line\nG1 X30 Z0.05 F1000  ; Wipe off tail\nG1 Z10		    ; Move away from bed\nG1 Y11 		    ; Move to Y-axis safe zone\nG92 E0 	            ; Zero extruder\nM564 S0 	    ; Safteys off\nM106 P2 S50         ; Enable exhaust fan\n{endif}\n\n{if temperature[0] == 0}\n; U1 Single Mode - Right Purge\nT1		    ; Switch to T1\nG1 Z20.0 F6000      ; Move Z to 20\nG92 E0              ; Zero Extruder\nM564 S0 	    ; Safteys off\nG1 X160 Y5 F1000    ; Move to unused front edge\nG1 Z0.30 F1000      ; Move closer to the bed\nG1 X40 E20 F1000    ; Deposit purge line\nG1 X30 Z0.05 F1000  ; Wipe off tail\nG1 Z10		    ; Move away from bed\nG1 Y11 		    ; Move to y safe zone\nG92 E0 		    ; Zero extruder\nM564 S0             ; Safteys off\nM106 P2 S50         ; Enable exhaust fan\n{endif}\n\n{if temperature[0] > 0 && temperature[1] > 0}\n; U1 T0/T1 Startup Script\nT1 		    ; Switch to T1\nG1 Z20.0 F6000      ; Move Z to 20\nG92 E0              ; Zero Extruder\nM564 S0 	    ; Safteys off\nG1 X160 Y5 F1000    ; Move to unused front edge\nG1 Z0.30 F1000      ; Move closer to the bed\nG1 X40 E20 F1000    ; Deposit purge line\nG1 X30 Z0.05 F1000  ; Wipe off tail\nG1 Z10		    ; Move away from bed\nG1 Y11 		    ; Move to y safe zone\nG92 E0 		    ; Zero extruder\n\nT0		    ; Switch to T0\nG1 X360 Y5 F1000    ; Move to unused front edge\nG1 Z0.30 F1000      ; Move closer to the bed\nG1 X240 E20 F1000   ; Deposit purge line\nG1 X230 Z0.05 F1000 ; Wipe off tail\nG1 Z10		    ; Move away from bed\nG1 Y11 		    ; Move to y safe zone\nG92 E0 		    ; Zero extruder\nM564 S1 	    ; Safteys on\nM106 P2 S50         ; Enable exhaust fan\n{endif}
+toolchange_gcode = 
+# thumbnails = 16x16,220x124
+
+[printer:MakerGear Ultra One 0.25 Nozzle]
+inherits = MakerGear Ultra One
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15,0.15
+min_layer_height = 0.05,0.05
+nozzle_diameter = 0.25,0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear Ultra One 0.35 Nozzle]
+inherits = MakerGear Ultra One
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+max_layer_height = 0.30,0.30
+min_layer_height = 0.1,0.1
+nozzle_diameter = 0.35,0.35
+printer_variant = 0.35
+
+[printer:MakerGear Ultra One 0.75 Nozzle]
+inherits = MakerGear Ultra One
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5,0.5
+min_layer_height = 0.15,0.15
+nozzle_diameter = 0.75,0.75
+printer_variant = 0.75
+retract_length = 1, 1
+retract_speed = 35, 35
+
+# -----------------------------------
+# MakerGear Ultra One (Duplication Mode)
+# -----------------------------------
+
+[printer:MakerGear Ultra One (Duplication Mode)]
+inherits = MakerGear Ultra One
+bed_shape = 0x0,203x0,203x355,0x355
+end_gcode = M106 P2 S0 ; turn off exhaust fan\n\nM104 S0 ; turn off extruder\nM104 S0 T0 ; turn off extruder\nM104 S0 T1; turn off extruder\nM104 S0 T2; turn off extruder\nM140 P0 S0 ; turn off bed\nM140 P1 S0 ; turn off bed\nM140 P2 S0 ; turn off bed\nM140 P3 S0 ; turn off bed\nM106 S0 ; turn off cooling fan\nG91 ; relative mode\nG1 Z20 ; move Z down 20mm\nG90;  absolute mode\n\nG28 XY ; home tool/s\nM502 ; set to firmware default values\nT0 ; defualt tool should always be T0
+extruders_count = 1
+nozzle_diameter = 0.50
+printer_model = MAKERGEAR_U1_DUPLICATION
+printer_notes = Dont remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_MAKERGEAR\nPRINTER_MODEL_MAKERGEAR_U1_DUPLICATION\n 
+printer_variant = 0.50
+start_gcode = ;U1 Rev0 Duplication Script - T0 and T1\n\nM203 X18000.00 Y18000.00 Z1200.00 U18000.00 E1800.00 ; U1 max feedrate mm/minute\n        M201 X1000 Y1000 Z10 U1000 E2000                    ; U1 Maximum Acceleration axes mm/s^2\n        M204 P2000 T2000           ; U1 Maximum Acceleration printing / travel mm/s^2\n        M566 X300 Y300 Z60 U300 E600 ; U1  instantenous speed change 'jerk' in mm/minute\n        M593 F0                     ;make sure dynamix acceleration is off \n\n\n; turn off T0 hot end to reduce ooze on the bed during startup. NOTE: this does not explicitly wait for the hotends to totally cool down\nM104 T0 S0\nM104 T1 S0\nM104 T2 S0\n\n\nM221 D0 S100 ;extruder rate for T0 is set in S3D so set to 100% here\nM221 D1 S100 ;extruder rate for T1 is set in S3D so set to 100% here\n\n\nM140 P0 S[first_layer_bed_temperature]				;Middle bed heater strip\nM140 P1 S[first_layer_bed_temperature]				;2nd from left and second from right bed heater\nM140 P2 S[first_layer_bed_temperature]				;Left bed heater strip\nM140 P3 S[first_layer_bed_temperature]				;Right bed heater strip\n\nM116 ; wait for all bed heaters to get to temp before probing. This will wait for cooldown if there is overshoot. \n\nG29 S2 ; Clear any meshes \nG28 XY; home XY\nG28 Z ;Home Z\nG32    ;Auto Level \nG28 Z ; rehome Z\n\n;Get hot ends up to temp\nM104 T0 S{first_layer_temperature[0]}\nM104 T1 S{first_layer_temperature[0]}\nM104 T2 S{first_layer_temperature[0]}\nM116 ; wait for all bed heaters to get to temp before probing. This will wait for cooldown if there is overshoot. \n\n\n;***Initial Purge***\nT2\nG1 Z20.0 F6000             ; Move Z to 20\n\nG92 E0                     ; Zero Extruder\n\nM564 S0 ; safteys off\nG1 X160 Y5F10000; move to unused front edge\nG1 Z0.30 F1000\nG1 X40 E20 F1000\nG1 X30 Z0.05 F1000 ; wipe off tail\nG1 Z10\nG1 Y11 ;safe zone\nG92 E0\n\nM564 S0 ; safteys off\n\n\nM106 P2 S100; exhaust fan change S value to enable (50 is a good starting value)\n\n; end startup script
+# thumbnails = 16x16,300x350
+
+[printer:MakerGear Ultra One 0.25 Nozzle (Duplication Mode)]
+inherits = MakerGear Ultra One (Duplication Mode)
+default_print_profile = 0.15mm Normal @0.25 nozzle MakerGear
+max_layer_height = 0.15
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+printer_variant = 0.25
+retract_length = 1
+retract_lift = 0.15
+retract_speed = 50
+
+[printer:MakerGear Ultra One 0.35 Nozzle (Duplication Mode)]
+inherits = MakerGear Ultra One (Duplication Mode)
+default_print_profile = 0.20mm Normal @0.35 nozzle MakerGear
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.35
+printer_variant = 0.35
+
+[printer:MakerGear Ultra One 0.75 Nozzle (Duplication Mode)]
+inherits = MakerGear Ultra One (Duplication Mode)
+default_print_profile = 0.25mm Quality @0.75 nozzle MakerGear
+max_layer_height = 0.5
+min_layer_height = 0.15
+nozzle_diameter = 0.75
+printer_variant = 0.75
+retract_length = 1
+retract_speed = 35

--- a/live/MakerGear/index.idx
+++ b/live/MakerGear/index.idx
@@ -1,2 +1,3 @@
 min_slic3r_version = 2.6.0-alpha1
+0.1.1 Adjusted M2, M2Dual and M3 starting scripts
 0.1.0 Initial version


### PR DESCRIPTION
- Deleted a redundant Z-axis movement in the M2 and M2 Dual starting scripts
  - Suggested in https://github.com/prusa3d/PrusaSlicer/issues/9938
- Lowered the feed rate of the following starting script movement command:
  `G1 X0 Y50 F9600 ; Move forward to avoid binder clips`
    - It was set to "F9600" and is now "F6000"