### PR TITLE
Adjust AnkerMake thumbnails to fix occasional wifi transfer issues

### DIFF
--- a/live/Anker/1.1.2.ini
+++ b/live/Anker/1.1.2.ini
@@ -1,0 +1,365 @@
+# Print profiles for the AnkerMake printers.
+
+[vendor]
+# Vendor name will be shown by the Config Wizard.
+name = AnkerMake
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the PrusaSlicer configuration to be downgraded.
+config_version = 1.1.2
+# Where to get the updates from?
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Anker/
+# changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
+
+# The printer models will be shown by the Configuration Wizard in this order,
+# also the first model installed & the first nozzle installed will be activated after install.
+# Printer model name will be shown by the installation wizard.
+
+[printer_model:M5]
+name = AnkerMake M5
+variants = 0.4
+technology = FFF
+family = AnkerMake
+bed_model = M5-bed.stl
+bed_texture = M5-texture_v2.svg
+thumbnail = M5_thumbnail_v2.png
+default_materials = Generic PLA+ @ANKER; Generic PLA @ANKER; Generic PET @ANKER; Generic ABS @ANKER; 
+
+# All presets starting with asterisk, for example *common*, are intermediate and they will
+# not make it into the user interface.
+
+# Common print preset
+[print:*common*]
+avoid_crossing_perimeters = 0
+bridge_acceleration = 2500
+bridge_angle = 0
+bridge_flow_ratio = 1
+bridge_speed = 50
+brim_separation = 0.1
+brim_type = outer_only
+brim_width = 0
+clip_multipart_objects = 1
+complete_objects = 0
+default_acceleration = 2500
+dont_support_bridges = 1
+elefant_foot_compensation = 0.2
+ensure_vertical_shell_thickness = 1
+external_perimeter_speed = 150
+external_perimeters_first = 0
+extra_perimeters = 0
+extruder_clearance_height = 30
+extruder_clearance_radius = 45
+extrusion_width = 0.4
+external_perimeter_extrusion_width = 0.44
+fill_angle = 45
+fill_density = 10%
+fill_pattern = grid
+first_layer_acceleration = 2500
+first_layer_acceleration_over_raft = 0
+first_layer_extrusion_width = 0.4
+first_layer_speed = 50%
+first_layer_speed_over_raft = 30
+gap_fill_enabled = 1
+gap_fill_speed = 150
+gcode_comments = 0
+infill_acceleration = 2500
+infill_anchor = 2.5
+infill_anchor_max = 12
+infill_every_layers = 1
+infill_extruder = 1
+infill_first = 0
+infill_extrusion_width = 0.4
+infill_only_where_needed = 0
+infill_overlap = 10%
+infill_speed = 250
+interface_shells = 0
+max_print_speed = 250
+max_volumetric_extrusion_rate_slope_negative = 0
+max_volumetric_extrusion_rate_slope_positive = 0
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+only_retract_when_crossing_perimeters = 0
+ooze_prevention = 0
+output_filename_format = {input_filename_base}_{layer_height}mm_{initial_filament_type}_{printer_model}.gcode
+overhangs = 1
+perimeter_acceleration = 2500
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.4
+perimeter_generator = classic
+perimeter_speed = 250
+perimeters = 3
+post_process = 
+print_settings_id = 
+raft_layers = 0
+resolution = 0.01
+seam_position = aligned
+single_extruder_multi_material_priming = 0
+skirt_distance = 3
+skirt_height = 1
+skirts = 3
+small_perimeter_speed = 150
+solid_infill_below_area = 0
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.4
+solid_infill_speed = 250
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material_auto = 0
+support_material = 0
+support_material_angle = 0
+support_material_buildplate_only = 0
+support_material_contact_distance = 0.1
+support_material_enforce_layers = 0
+support_material_extruder = 0
+support_material_interface_contact_loops = 0
+support_material_interface_extruder = 0
+support_material_interface_layers = 2
+support_material_interface_spacing = 0.2
+support_material_interface_speed = 80%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 150
+support_material_synchronize_layers = 0
+support_material_threshold = 55
+support_material_with_sheath = 0
+support_material_xy_spacing = 50%
+thick_bridges = 0
+thin_walls = 0
+top_solid_infill_speed = 150
+top_infill_extrusion_width = 0.4
+top_fill_pattern = rectilinear
+bottom_fill_pattern = rectilinear
+travel_speed = 250
+travel_speed_z = 0
+wipe_tower = 0
+wipe_tower_bridging = 10
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 170
+wipe_tower_y = 140
+xy_size_compensation = 0
+
+[print:*0.10mm*]
+inherits = *common*
+layer_height = 0.10
+first_layer_height = 0.10
+bottom_solid_layers = 7
+top_solid_layers = 9
+bridge_flow_ratio = 1
+
+[print:*0.20mm*]
+inherits = *common*
+layer_height = 0.20
+first_layer_height = 0.14
+bottom_solid_layers = 4
+top_solid_layers = 5
+
+[print:*0.30mm*]
+inherits = *common*
+layer_height = 0.30
+first_layer_height = 0.21
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+
+[print:0.10 mm HIGHDETAIL (0.4 mm nozzle) @ANKER]
+inherits = *0.10mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
+
+[print:0.20 mm NORMAL (0.4 mm nozzle) @ANKER]
+inherits = *0.20mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
+
+
+[print:0.30 mm SUPERDRAFT (0.4 mm nozzle) @ANKER]
+inherits = *0.30mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
+
+# When submitting new filaments please print the following temperature tower at 0.1mm layer height:
+#   https://www.thingiverse.com/thing:2615842
+# Pay particular attention to bridging, overhangs and retractions.
+# Also print the following bed adhesion test at 0.1 layer height as well:
+#   https://www.prusaprinters.org/prints/4634-bed-adhesion-warp-test
+# At least for PLA, please keep bed temp at 60, as many Creality printers do not have any ABL
+# So having some leeway to get good bed adhesion is not a luxury for many users
+
+[filament:*common*]
+cooling = 0
+compatible_printers = 
+extrusion_multiplier = 1
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 30
+slowdown_below_layer_time = 8
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANKERMAKE.*/
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+fan_below_layer_time = 100
+filament_colour = #DDDDDD
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 20
+first_layer_bed_temperature = 60
+first_layer_temperature = 230
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+temperature = 200
+
+[filament:*PLA+*]
+inherits = *common*
+bed_temperature = 60
+fan_below_layer_time = 100
+filament_colour = #DDDDDD
+filament_type = PLA+
+filament_density = 1.24
+filament_cost = 20
+first_layer_bed_temperature = 60
+first_layer_temperature = 230
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+temperature = 200
+
+[filament:*PET*]
+inherits = *common*
+bed_temperature = 80
+disable_fan_first_layers = 2
+fan_below_layer_time = 20
+filament_colour = #DDDDDD
+filament_type = PETG
+filament_density = 1.27
+filament_cost = 30
+first_layer_bed_temperature = 80
+first_layer_temperature = 260
+fan_always_on = 1
+max_fan_speed = 50
+min_fan_speed = 50
+bridge_fan_speed = 100
+temperature = 260
+
+[filament:*ABS*]
+inherits = *common*
+bed_temperature = 90
+disable_fan_first_layers = 2
+fan_below_layer_time = 20
+filament_colour = #DDDDDD
+filament_type = ABS
+filament_density = 1.04
+filament_cost = 20
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+fan_always_on = 0
+max_fan_speed = 0
+min_fan_speed = 0
+bridge_fan_speed = 30
+top_fan_speed = 0
+temperature = 260
+
+[filament:Generic PLA @ANKER]
+inherits = *PLA*
+filament_vendor = Generic
+
+[filament:Generic PLA+ @ANKER]
+inherits = *PLA+*
+filament_vendor = Generic
+
+[filament:Generic PETG @ANKER]
+inherits = *PET*
+filament_vendor = Generic
+
+[filament:Generic ABS @ANKER]
+inherits = *ABS*
+first_layer_bed_temperature = 90
+bed_temperature = 90
+filament_vendor = Generic
+
+
+# Common printer preset
+[printer:*common*]
+printer_technology = FFF
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;{layer_z}
+between_objects_gcode = 
+pause_print_gcode = 
+deretract_speed = 60
+extruder_colour = #FCE94F
+extruder_offset = 0x0
+gcode_flavor = marlin
+silent_mode = 1
+remaining_times = 1
+machine_max_acceleration_e = 2500
+machine_max_acceleration_extruding = 2500
+machine_max_acceleration_retracting = 2500
+machine_max_acceleration_travel = 1500,1250
+machine_max_acceleration_x = 2500
+machine_max_acceleration_y = 2500
+machine_max_acceleration_z = 2500
+machine_max_feedrate_e = 100
+machine_max_feedrate_x = 300
+machine_max_feedrate_y = 300
+machine_max_feedrate_z = 20
+machine_max_jerk_e = 3
+machine_max_jerk_x = 15
+machine_max_jerk_y = 15
+machine_max_jerk_z = 0.3
+machine_min_extruding_rate = 0
+machine_min_travel_rate = 0
+layer_gcode = ;AFTER_LAYER_CHANGE\n;{layer_z}
+max_print_height = 250
+printer_notes = 
+printer_settings_id = 
+retract_before_travel = 3
+retract_before_wipe = 0
+retract_layer_change = 1
+retract_length_toolchange = 4
+retract_lift = 0
+retract_lift_above = 0
+retract_lift_below = 0
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 60
+single_extruder_multi_material = 0
+thumbnails = 128x128
+thumbnails_format = PNG
+toolchange_gcode = 
+use_firmware_retraction = 0
+use_relative_e_distances = 0
+use_volumetric_e = 0
+variable_layer_height = 1
+wipe = 0
+z_offset = 0
+default_filament_profile = Generic PLA+ @ANKER
+start_gcode = M104 S{first_layer_temperature[0]} ; set final nozzle temp\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; wait for nozzle temp to stabilize\nG28 ;Home\nM420 S1; restore saved Auto Bed Leveling data\nG1 E10 F3600; push out retracted filament(fix for over retraction after prime)
+end_gcode = M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM84
+
+[printer:*M5*]
+inherits = *common*
+bed_shape = 0x0,235x0,235x235,0x235
+max_print_height = 250
+printer_model = M5
+retract_length = 3
+retract_speed = 60
+deretract_speed = 60
+retract_before_travel = 3
+retract_before_wipe = 0%
+printer_notes = Do not remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_ANKERMAKE\nPRINTER_MODEL_M5
+
+[printer:AnkerMake M5 (0.4 mm nozzle)]
+inherits = *M5*
+nozzle_diameter = 0.4
+printer_variant = 0.4
+min_layer_height = 0.08
+max_layer_height = 0.32
+retract_lift_above = 0
+default_print_profile = 0.2 mm OPTIMAL (0.4 mm nozzle) @ANKER

--- a/live/Anker/index.idx
+++ b/live/Anker/index.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.6.0-alpha4
+1.1.1 Adjust thumbnails to fix occasional wifi transfer issues
 1.1.1 Initial official version
 1.0.1 Initial Version
 min_slic3r_version = 2.6.0-alpha1

--- a/live/Anker/index.idx
+++ b/live/Anker/index.idx
@@ -1,5 +1,5 @@
 min_slic3r_version = 2.6.0-alpha4
-1.1.1 Adjust thumbnails to fix occasional wifi transfer issues
+1.1.2 Adjust thumbnails to fix occasional wifi transfer issues
 1.1.1 Initial official version
 1.0.1 Initial Version
 min_slic3r_version = 2.6.0-alpha1


### PR DESCRIPTION
Lines 333-334: In the previous version, the two thumbnails generated could cause a wifi transmission error. Modifying it to one smaller png solves the problem.

```
thumbnails = 128x128
thumbnails_format = PNG
```

Additional Minor changes:

- Line 348: fixed typo in bed size format (replaced `bed_shape = 0x0,235-0,235x235,0x235` with `bed_shape = 0x0,235x0,235x235,0x235`
- Fixed typo on line 356.
