### PR TITLE
add pre-supported print settings for SL1 and SL1S

### DIFF
--- a/live/PrusaResearch/1.14.0.ini
+++ b/live/PrusaResearch/1.14.0.ini
@@ -16372,12 +16372,19 @@ support_pillar_diameter = 1
 output_filename_format = [input_filename_base].sl1s
 compatible_printers_condition = printer_model=="SL1S"
 
+[sla_print:*pre-supported*]
+pad_enable = 0
+supports_enable = 0
+
 # SL1 #
 
 [sla_print:0.025 UltraDetail]
 inherits = *common*
 layer_height = 0.025
 support_head_width = 2
+
+[sla_print:0.025 UltraDetail pre-supported]
+inherits = 0.025 UltraDetail; *pre-supported*
 
 ; [sla_print:0.035 Detail]
 ; inherits = *common*
@@ -16387,12 +16394,18 @@ support_head_width = 2
 inherits = *common*
 layer_height = 0.05
 
+[sla_print:0.05 Normal pre-supported]
+inherits = 0.05 Normal; *pre-supported*
+
 [sla_print:0.1 Fast]
 inherits = *common*
 layer_height = 0.1
 support_head_front_diameter = 0.5
 support_head_penetration = 0.5
 support_pillar_diameter = 1.3
+
+[sla_print:0.1 Fast pre-supported]
+inherits = 0.1 Fast; *pre-supported*
 
 # SL1S #
 
@@ -16401,15 +16414,24 @@ inherits = *SL1S*
 layer_height = 0.025
 support_head_width = 3
 
+[sla_print:0.025 UltraDetail pre-supported @SL1S]
+inherits = 0.025 UltraDetail @SL1S; *pre-supported*
+
 [sla_print:0.05 Normal @SL1S]
 inherits = *SL1S*
 layer_height = 0.05
+
+[sla_print:0.05 Normal pre-supported @SL1S]
+inherits = 0.05 Normal @SL1S; *pre-supported*
 
 [sla_print:0.1 Fast @SL1S]
 inherits = *SL1S*
 layer_height = 0.1
 support_head_front_diameter = 0.6
 support_head_penetration = 0.6
+
+[sla_print:0.1 Fast pre-supported @SL1S]
+inherits = 0.1 Fast @SL1S; *pre-supported*
 
 ########### Materials
 


### PR DESCRIPTION
As I often print pre-supported models and use PrusaSlicer on different computers, I've added print settings for pre-supported models for the SL1 and SL1S with the following changes to the normal print settings:

```
pad_enable = 0
supports_enable = 0
```